### PR TITLE
Update language services packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -671,22 +671,22 @@
       }
     },
     "node_modules/@github/actions-expressions": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-expressions/0.1.180/e503b90a6092a17c7391865df5c2664903088614",
-      "integrity": "sha512-igHjhzZKLbXUGtUb8Oh5iiiUXVsYKF8+hRzWxD4dtT+3F6XSCJLq7F5dUk4qEwahtolIzd5y4v1i2LD/jzu8mw==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-expressions/0.1.181/26f81c12af7023dfb4db513fb477b2659e3d81db",
+      "integrity": "sha512-kdTojNieHm8cgYVXi6IyWjtk2O/qyyn3tFnqGhkc911e4XGtZ5+RPpJkqLO2CqoJSeWA0LzFMIFLBR2SVZu64g==",
       "license": "MIT",
       "engines": {
         "node": ">= 16.15"
       }
     },
     "node_modules/@github/actions-languageserver": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageserver/0.1.180/465b9c7d760a969448aff950e5eeec672502d3e5",
-      "integrity": "sha512-EvFZ5Ww0xmV3uG/StaJPG/ZL0aLedzRG5sln5EfxCwfTAWlBkfiOtZsV9Cmow2jj4nvFWqrrdHWo6NkWAPzbxA==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageserver/0.1.181/8ee9f0861ffda79bbab38451a655813cf68c4e01",
+      "integrity": "sha512-wCEnJNEvyYWh+cFfFwBYKg0m3Mgpw9pkaYZ40fzso3qJca3graPMMrbKCl71TBKQ10BO1Y2KH9NLj5VULhv2Ug==",
       "license": "MIT",
       "dependencies": {
-        "@github/actions-languageservice": "^0.1.180",
-        "@github/actions-workflow-parser": "^0.1.180",
+        "@github/actions-languageservice": "^0.1.181",
+        "@github/actions-workflow-parser": "^0.1.181",
         "@octokit/rest": "^19.0.7",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -711,13 +711,13 @@
       }
     },
     "node_modules/@github/actions-languageservice": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageservice/0.1.180/d3cd3c3d67de7c6febc100fc980f5919bb22ef09",
-      "integrity": "sha512-zBVJdbgVXJdOsE/h5650+J8nJSiz2z5Ccb136NXRgjrsfSQyPMbyaY07NBdkRxhggZdcjrWU03PurBXmF5B8Rg==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageservice/0.1.181/ace009eedf79409ce04f2b2897ab22614190e003",
+      "integrity": "sha512-I5SJOGukF0rKCtTNBl8VlsdkvhkdjcV58QVKj3lLNF1xwYTzJFjrH9CbOdRPbe34vgFU8dsBYLu8YVXApoA5Iw==",
       "license": "MIT",
       "dependencies": {
-        "@github/actions-expressions": "^0.1.180",
-        "@github/actions-workflow-parser": "^0.1.180",
+        "@github/actions-expressions": "^0.1.181",
+        "@github/actions-workflow-parser": "^0.1.181",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.7",
@@ -728,12 +728,12 @@
       }
     },
     "node_modules/@github/actions-workflow-parser": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-workflow-parser/0.1.180/f75e4f4d62a6e25265774d6bf28096998cd698d1",
-      "integrity": "sha512-hewBFAA3PYyi7x9TOlBoRCWae0gy9+NrBWIboKvmd3MyTmkpG9rb+2C0tjSIRnox1qwnLz+u4FJB8+PXd8ruHA==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-workflow-parser/0.1.181/678956bbdee32607ba56ef7ba87e89eaa6248780",
+      "integrity": "sha512-akeQ9QRA5SkJh10Dn1NM++J4lcpyxMPdM8P+veFE++bYL+bDmyVnfk2Pdnl3QicC799garsVLhkxhkMNaz6JcQ==",
       "license": "MIT",
       "dependencies": {
-        "@github/actions-expressions": "^0.1.180",
+        "@github/actions-expressions": "^0.1.181",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       },
@@ -10742,17 +10742,17 @@
       }
     },
     "@github/actions-expressions": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-expressions/0.1.180/e503b90a6092a17c7391865df5c2664903088614",
-      "integrity": "sha512-igHjhzZKLbXUGtUb8Oh5iiiUXVsYKF8+hRzWxD4dtT+3F6XSCJLq7F5dUk4qEwahtolIzd5y4v1i2LD/jzu8mw=="
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-expressions/0.1.181/26f81c12af7023dfb4db513fb477b2659e3d81db",
+      "integrity": "sha512-kdTojNieHm8cgYVXi6IyWjtk2O/qyyn3tFnqGhkc911e4XGtZ5+RPpJkqLO2CqoJSeWA0LzFMIFLBR2SVZu64g=="
     },
     "@github/actions-languageserver": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageserver/0.1.180/465b9c7d760a969448aff950e5eeec672502d3e5",
-      "integrity": "sha512-EvFZ5Ww0xmV3uG/StaJPG/ZL0aLedzRG5sln5EfxCwfTAWlBkfiOtZsV9Cmow2jj4nvFWqrrdHWo6NkWAPzbxA==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageserver/0.1.181/8ee9f0861ffda79bbab38451a655813cf68c4e01",
+      "integrity": "sha512-wCEnJNEvyYWh+cFfFwBYKg0m3Mgpw9pkaYZ40fzso3qJca3graPMMrbKCl71TBKQ10BO1Y2KH9NLj5VULhv2Ug==",
       "requires": {
-        "@github/actions-languageservice": "^0.1.180",
-        "@github/actions-workflow-parser": "^0.1.180",
+        "@github/actions-languageservice": "^0.1.181",
+        "@github/actions-workflow-parser": "^0.1.181",
         "@octokit/rest": "^19.0.7",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -10776,12 +10776,12 @@
       }
     },
     "@github/actions-languageservice": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageservice/0.1.180/d3cd3c3d67de7c6febc100fc980f5919bb22ef09",
-      "integrity": "sha512-zBVJdbgVXJdOsE/h5650+J8nJSiz2z5Ccb136NXRgjrsfSQyPMbyaY07NBdkRxhggZdcjrWU03PurBXmF5B8Rg==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-languageservice/0.1.181/ace009eedf79409ce04f2b2897ab22614190e003",
+      "integrity": "sha512-I5SJOGukF0rKCtTNBl8VlsdkvhkdjcV58QVKj3lLNF1xwYTzJFjrH9CbOdRPbe34vgFU8dsBYLu8YVXApoA5Iw==",
       "requires": {
-        "@github/actions-expressions": "^0.1.180",
-        "@github/actions-workflow-parser": "^0.1.180",
+        "@github/actions-expressions": "^0.1.181",
+        "@github/actions-workflow-parser": "^0.1.181",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.7",
@@ -10789,11 +10789,11 @@
       }
     },
     "@github/actions-workflow-parser": {
-      "version": "0.1.180",
-      "resolved": "https://npm.pkg.github.com/download/@github/actions-workflow-parser/0.1.180/f75e4f4d62a6e25265774d6bf28096998cd698d1",
-      "integrity": "sha512-hewBFAA3PYyi7x9TOlBoRCWae0gy9+NrBWIboKvmd3MyTmkpG9rb+2C0tjSIRnox1qwnLz+u4FJB8+PXd8ruHA==",
+      "version": "0.1.181",
+      "resolved": "https://npm.pkg.github.com/download/@github/actions-workflow-parser/0.1.181/678956bbdee32607ba56ef7ba87e89eaa6248780",
+      "integrity": "sha512-akeQ9QRA5SkJh10Dn1NM++J4lcpyxMPdM8P+veFE++bYL+bDmyVnfk2Pdnl3QicC799garsVLhkxhkMNaz6JcQ==",
       "requires": {
-        "@github/actions-expressions": "^0.1.180",
+        "@github/actions-expressions": "^0.1.181",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       }


### PR DESCRIPTION
Pulling in the latest language services packages to fix a bug where auto-completion wasn't working properly on an empty workflow.

```shell
npm i @github/actions-workflow-parser@latest @github/actions-languageserver@latest
./update-package-locks.sh
# reverted change to package.json
./update-package-locks.sh
```