### PR TITLE
Use pull requests to trigger a new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,51 @@ on:
     paths:
       - package.json
 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
 jobs:
+  check-version-change:
+    outputs:
+      changed: ${{ steps.check-version.outputs.result }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check if version has changed
+        id: check-version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const version = '${{ github.event.inputs.version }}' || require('./package.json').version;
+            // Find a release for that version
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: `release-v${version}`,
+            }).catch(() => null);
+
+            // If the release exists, the version has not changed
+            if (release) {
+              console.log(`Version ${version} has an existing release`);
+              console.log(release.data.html_url);
+              core.summary.addLink(`Release v${version}`, release.data.html_url);
+              await core.summary.write();
+              return "false";
+            }
+            console.log(`Version ${version} does not have a release`);
+            return true;
+
   release:
+    needs: check-version-change
+    if: ${{ needs.check-version-change.outputs.changed == 'true' }}
+
     runs-on: ubuntu-latest
 
     permissions:
@@ -67,6 +110,9 @@ jobs:
                 "content-length": fs.statSync(path).size
               }
             });
+
+            core.summary.addLink(`Release v${version}`, release.data.html_url);
+            await core.summary.write();
 
   publish:
     environment: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-name: Release and publish extension
+name: Create release PR
 
-run-name: Release new version
+run-name: Create release PR for v${{ github.event.inputs.version }}
 
 on:
   workflow_dispatch:
@@ -37,7 +37,7 @@ jobs:
           git add package.json package-lock.json
           git commit -m "Release extension version ${{ inputs.version }}"
 
-          git push
+          git push --set-upstream origin release/${{ inputs.version }}
 
       - name: Create PR
         run: |
@@ -46,3 +46,5 @@ jobs:
             --body "Release version ${{ inputs.version }}" \
             --base main \
             --head release/${{ inputs.version }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This splits the previous release workflow into two workflows:
1. Creates a release PR with a new package version
2. Creates the release and publishes the extension when the `version` is changed in `package.json`

This helps automate the release process and avoid having the workflows push directly to `main` (which doesn't work well with branch protection rules).

In the future, we can update the PR release workflow to include a changelog.