### PR TITLE
Authenticate with `npm` in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,13 +68,17 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 16.x
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
 
       - name: Parse version from package.json
         run: |
           echo "EXT_VERSION=$(node -p -e "require('./package.json').version")" >> $GITHUB_ENV
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm run package
 


### PR DESCRIPTION
The language services packages are still currently private, so we need to configure auth. This matches the configuration used in the build workflow.