### PR TITLE
Fix job summary in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
               }
             });
 
-            core.summary.addLink(`Release v${version}`, release.data.html_url);
+            core.summary.addLink(`Release v${{ env.EXT_VERSION }}`, release.data.html_url);
             await core.summary.write();
 
   publish:


### PR DESCRIPTION
This was pulled from the `check-version-change` job, but we aren't defining a `version` variable.