### PR TITLE
Send raw data when uploading release asset

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              data: fs.readFileSync(path).toString(),
+              data: fs.readFileSync(path),
               name: "vscode-github-actions-${{ env.EXT_VERSION }}.vsix",
               headers: {
                 "content-type": "application/vsix",


### PR DESCRIPTION
`uploadReleaseAsset` is expecting the raw data

>GitHub expects the asset data in its raw binary form, rather than JSON. You will send the raw binary content of the asset as the request body.
https://octokit.github.io/rest.js/v19#repos-upload-release-asset