### PR TITLE
Remove `X-GitHub-Api-Version` header for now

### DIFF
--- a/src/api/canReachGitHubAPI.ts
+++ b/src/api/canReachGitHubAPI.ts
@@ -15,11 +15,7 @@ export async function canReachGitHubAPI() {
   return await cache.get("canReachGitHubAPI", undefined, async () => {
     try {
       const octokit = getClient(session.accessToken);
-      await octokit.request("GET /", {
-        headers: {
-          "X-GitHub-Api-Version": "2022-11-28"
-        }
-      });
+      await octokit.request("GET /");
     } catch (e) {
       logError(e as Error, "Error getting GitHub context");
       return false;


### PR DESCRIPTION
This header is causing some CORS policy issues when running the extension in a browser context. Once this header is allowed, we can add it back.