### PR TITLE
Add `packages: read` permissions to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: read
 
     env:
       EXT_VERSION: "" # will be set in the workflow


### PR DESCRIPTION
The language services packages are currently organization packages, so we need `packages: read` permissions to download them.