### PR TITLE
chore: Add missing Dependabot schedule key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,7 @@ registries:
 updates:
   - package-ecosystem: npm
     directory: "/"
+    schedule:
+      interval: weekly
     registries:
       - npm-github


### PR DESCRIPTION
Noticed that the schema validation was flagging the missing key in VScode