### PR TITLE
feat: add snippets for shells and workflow expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Be more confident when authoring and modifying workflows. Find errors before com
 
 ![Video showing workflow validation and auto-completion](./media/authoring.gif)
 
+**Snippets**: the extension provides snippets to speed up creating workflows
+
 ## Getting started
 
 1. Install the extension from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,12 @@
   "main": "./dist/extension-node.js",
   "browser": "./dist/extension-web.js",
   "contributes": {
+    "snippets": [
+      {
+        "language": "github-actions-workflow",
+        "path": "./snippets/snippets.json"
+      }
+    ],
     "languages": [
       {
         "id": "github-actions-workflow",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,0 +1,30 @@
+{
+    "not": {
+        "description": "! operator",
+        "prefix": "not",
+        "body": [
+            "!${1:expression}"
+        ]
+    },
+    "compare to": {
+        "description": "comparison operator",
+        "prefix": "compare-to",
+        "body": [
+            "${1:expression} ${2|<,>,<=,>=,==,!=|} ${3:expression}"
+        ]
+    },
+    "and": {
+        "description": "&& operator",
+        "prefix": "and",
+        "body": [
+            "${1:expression} && ${2:expression}"
+        ]
+    },
+    "or": {
+        "description": "|| operator",
+        "prefix": "or",
+        "body": [
+            "${1:expression} || ${2:expression}"
+        ]
+    }
+}

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -210,6 +210,41 @@
             "sed ${1|--regexp-extended,-E|} 'y/${2:source-characters}/${3:replacement-characters}/g' ${4:path/to/file}"
         ]
     },
+    "awk filter by pattern": {
+        "description": "pattern filter",
+        "prefix": "awk:filter-by-pattern",
+        "body": [
+            "awk '/${1:pattern}/' ${2:path/to/file}"
+        ]
+    },
+    "awk filter by line number": {
+        "description": "line number filter",
+        "prefix": "awk:filter-by-line-number",
+        "body": [
+            "awk 'NR == ${1:number}' ${2:path/to/file}"
+        ]
+    },
+    "awk filter by line numbers": {
+        "description": "line number filter",
+        "prefix": "awk:filter-by-line-numbers",
+        "body": [
+            "awk 'NR >= ${1:from} && NR <= ${2:to}' ${3:path/to/file}"
+        ]
+    },
+    "awk replace single": {
+        "description": "singule replacement",
+        "prefix": "awk:single-replacement",
+        "body": [
+            "awk '{ sub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
+        ]
+    },
+    "awk replace globally": {
+        "description": "global replacement",
+        "prefix": "awk:global-replacement",
+        "body": [
+            "awk '{ gsub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
+        ]
+    },
     "step": {
         "description": "step definition",
         "prefix": "step",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -26,5 +26,52 @@
         "body": [
             "${1:expression} || ${2:expression}"
         ]
+    },
+    "bash if": {
+        "description": "if operator",
+        "prefix": "bash:if",
+        "body": [
+            "if ${1:command}; then",
+            "\t$0",
+            "fi"
+        ]
+    },
+    "bash if else": {
+        "description": "if else operator",
+        "prefix": "bash:if-else",
+        "body": [
+            "if ${1:command}; then",
+            "\t${2:echo}",
+            "else",
+            "\t$0",
+            "fi"
+        ]
+    },
+    "bash while": {
+        "description": "while operator",
+        "prefix": "bash:while",
+        "body": [
+            "while ${1:command}; do",
+            "\t$0",
+            "done"
+        ]
+    },
+    "bash until": {
+        "description": "until operator",
+        "prefix": "bash:until",
+        "body": [
+            "until ${1:command}; do",
+            "\t$0",
+            "done"
+        ]
+    },
+    "bash for": {
+        "description": "for operator",
+        "prefix": "bash:for",
+        "body": [
+            "for ${1:variable} in ${2:list}; do",
+            "\t$0",
+            "done"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -168,6 +168,20 @@
             "}"
         ]
     },
+    "env change directory": {
+        "description": "directory change",
+        "prefix": "env:directory-change",
+        "body": [
+            "sed ${1|--chdir,-C|} ${2:command}"
+        ]
+    },
+    "env ignore environment": {
+        "description": "environment ignore",
+        "prefix": "env:environment-ignore",
+        "body": [
+            "sed ${1|--ignore-environment,-i|} ${2:command}"
+        ]
+    },
     "sed filter by pattern": {
         "description": "pattern filter",
         "prefix": "sed:filter-by-pattern",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -182,9 +182,16 @@
             "sed ${1|--ignore-environment,-i|} ${2:command}"
         ]
     },
-    "sed filter by pattern": {
-        "description": "pattern filter",
-        "prefix": "sed:filter-by-pattern",
+    "sed print": {
+        "description": "line print",
+        "prefix": "sed:print",
+        "body": [
+            "sed '' ${1:path/to/file}"
+        ]
+    },
+    "sed filter by line pattern": {
+        "description": "line pattern filter",
+        "prefix": "sed:filter-by-line-pattern",
         "body": [
             "sed ${1|--regexp-extended,-E|} ${2|--quiet,-n|} '/${3:pattern}/p' ${4:path/to/file}"
         ]
@@ -204,7 +211,7 @@
         ]
     },
     "sed replace single": {
-        "description": "singule replacement",
+        "description": "single replacement",
         "prefix": "sed:single-replacement",
         "body": [
             "sed ${1|--regexp-extended,-E|} 's/${2:pattern}/${3:replacement}/' ${4:path/to/file}"
@@ -224,9 +231,16 @@
             "sed ${1|--regexp-extended,-E|} 'y/${2:source-characters}/${3:replacement-characters}/g' ${4:path/to/file}"
         ]
     },
-    "awk filter by pattern": {
-        "description": "pattern filter",
-        "prefix": "awk:filter-by-pattern",
+    "awk print": {
+        "description": "line print",
+        "prefix": "awk:print",
+        "body": [
+            "awk '{ print $0 }' ${1:path/to/file}"
+        ]
+    },
+    "awk filter by line pattern": {
+        "description": "line pattern filter",
+        "prefix": "awk:filter-by-line-pattern",
         "body": [
             "awk '/${1:pattern}/' ${2:path/to/file}"
         ]
@@ -246,7 +260,7 @@
         ]
     },
     "awk replace single": {
-        "description": "singule replacement",
+        "description": "single replacement",
         "prefix": "awk:single-replacement",
         "body": [
             "awk '{ sub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -272,7 +272,7 @@
         "body": [
             "${1:job}:",
             "  name: ${2:name}",
-            "  runs-on: ${3|ubuntu-latest,macos-latest,windows-latest|}",
+            "  runs-on: ${3:os}",
             "  steps:",
             "  - uses: actions/checkout@v${4:3}",
             "  - run: |",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -31,7 +31,7 @@
         "description": "if operator",
         "prefix": "bash:if",
         "body": [
-            "if ${1:command}; then",
+            "if ${1:condition}; then",
             "\t$0",
             "fi"
         ]
@@ -40,7 +40,7 @@
         "description": "if else operator",
         "prefix": "bash:if-else",
         "body": [
-            "if ${1:command}; then",
+            "if ${1:condition}; then",
             "\t${2:echo}",
             "else",
             "\t$0",
@@ -51,7 +51,7 @@
         "description": "while operator",
         "prefix": "bash:while",
         "body": [
-            "while ${1:command}; do",
+            "while ${1:condition}; do",
             "\t$0",
             "done"
         ]
@@ -60,7 +60,7 @@
         "description": "until operator",
         "prefix": "bash:until",
         "body": [
-            "until ${1:command}; do",
+            "until ${1:condition}; do",
             "\t$0",
             "done"
         ]
@@ -78,7 +78,7 @@
         "description": "if operator",
         "prefix": "cmd:if",
         "body": [
-            "if ${1:command} (",
+            "if ${1:condition} (",
             "\t$0",
             ")"
         ]
@@ -87,7 +87,7 @@
         "description": "if else operator",
         "prefix": "cmd:if-else",
         "body": [
-            "if ${1:command} (",
+            "if ${1:condition} (",
             "\t${2:echo}",
             ") else (",
             "\t$0",
@@ -107,7 +107,7 @@
         "description": "if operator",
         "prefix": "pwsh:if",
         "body": [
-            "if (${1:command})",
+            "if (${1:condition})",
             "{",
             "\t$0",
             "}"
@@ -117,7 +117,7 @@
         "description": "if else operator",
         "prefix": "pwsh:if-else",
         "body": [
-            "if (${1:command})",
+            "if (${1:condition})",
             "{",
             "\t${2:echo}",
             "}",
@@ -131,7 +131,7 @@
         "description": "while operator",
         "prefix": "pwsh:while",
         "body": [
-            "while (${1:command})",
+            "while (${1:condition})",
             "{",
             "\t$0",
             "}"
@@ -145,7 +145,7 @@
             "{",
             "\t$0",
             "}",
-            "while (${1:command})"
+            "while (${1:condition})"
         ]
     },
     "pwsh for": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -252,6 +252,13 @@
             "${1|Build,Lint,Test|} with ${2|`,',\"|}${3:tool}$2"
         ]
     },
+    "command": {
+        "description": "command",
+        "prefix": "command",
+        "body": [
+            "echo \"::${1|debug,notice,error,endgroup,echo,add-mask,group,warning|} ${2:parameter=value...}::${3:value}\""
+        ]
+    },
     "trigger": {
         "description": "trigger definition",
         "prefix": "trigger",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -102,5 +102,70 @@
             "\t$0",
             ")"
         ]
+    },
+    "pwsh if": {
+        "description": "if operator",
+        "prefix": "pwsh:if",
+        "body": [
+            "if (${1:command})",
+            "{",
+            "\t$0",
+            "}"
+        ]
+    },
+    "pwsh if else": {
+        "description": "if else operator",
+        "prefix": "pwsh:if-else",
+        "body": [
+            "if (${1:command})",
+            "{",
+            "\t${2:echo}",
+            "}",
+            "else",
+            "{",
+            "\t$0",
+            "}"
+        ]
+    },
+    "pwsh while": {
+        "description": "while operator",
+        "prefix": "pwsh:while",
+        "body": [
+            "while (${1:command})",
+            "{",
+            "\t$0",
+            "}"
+        ]
+    },
+    "pwsh do": {
+        "description": "do operator",
+        "prefix": "pwsh:do",
+        "body": [
+            "do",
+            "{",
+            "\t$0",
+            "}",
+            "while (${1:command})"
+        ]
+    },
+    "pwsh for": {
+        "description": "for operator",
+        "prefix": "pwsh:for",
+        "body": [
+            "for (${1:variable}=${2:value}; ${3:condition}; ${4:command})",
+            "{",
+            "\t$0",
+            "}"
+        ]
+    },
+    "pwsh foreach": {
+        "description": "foreach operator",
+        "prefix": "pwsh:foreach",
+        "body": [
+            "for (${1:item} in ${2:list})",
+            "{",
+            "\t$0",
+            "}"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -167,5 +167,27 @@
             "\t$0",
             "}"
         ]
+    },
+    "step": {
+        "description": "step definition",
+        "prefix": "step",
+        "body": [
+            "- name: ${1:name}",
+            "  run: |",
+            "    $0"
+        ]
+    },
+    "job": {
+        "description": "job definition",
+        "prefix": "job",
+        "body": [
+            "${1:job}:",
+            "  name: ${2:name}",
+            "  runs-on: ${3|ubuntu-latest,macos-latest,windows-latest|}",
+            "  steps:",
+            "  - uses: actions/checkout@v${4:3}",
+            "  - run: |",
+            "      $0"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -168,6 +168,48 @@
             "}"
         ]
     },
+    "sed filter by pattern": {
+        "description": "pattern filter",
+        "prefix": "sed:filter-by-pattern",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} ${2|--quiet,-n|} '/${3:pattern}/p' ${4:path/to/file}"
+        ]
+    },
+    "sed filter by line number": {
+        "description": "line number filter",
+        "prefix": "sed:filter-by-line-number",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} ${2|--quiet,-n|} '${3:number}p' ${4:path/to/file}"
+        ]
+    },
+    "sed filter by line numbers": {
+        "description": "line number filter",
+        "prefix": "sed:filter-by-line-numbers",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} ${2|--quiet,-n|} '${3:from},${4:to}p' ${5:path/to/file}"
+        ]
+    },
+    "sed replace single": {
+        "description": "singule replacement",
+        "prefix": "sed:single-replacement",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} 's/${2:pattern}/${3:replacement}/' ${4:path/to/file}"
+        ]
+    },
+    "sed replace globally": {
+        "description": "global replacement",
+        "prefix": "sed:global-replacement",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} 's/${2:pattern}/${3:replacement}/g' ${4:path/to/file}"
+        ]
+    },
+    "sed transliterate": {
+        "description": "transliteration",
+        "prefix": "sed:transliteration",
+        "body": [
+            "sed ${1|--regexp-extended,-E|} 'y/${2:source-characters}/${3:replacement-characters}/g' ${4:path/to/file}"
+        ]
+    },
     "step": {
         "description": "step definition",
         "prefix": "step",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -245,6 +245,13 @@
             "awk '{ gsub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
         ]
     },
+    "description": {
+        "description": "step or job description",
+        "prefix": "description",
+        "body": [
+            "${1|Build,Lint,Test|} with `${2:tool}`"
+        ]
+    },
     "trigger": {
         "description": "trigger definition",
         "prefix": "trigger",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -73,5 +73,34 @@
             "\t$0",
             "done"
         ]
+    },
+    "cmd if": {
+        "description": "if operator",
+        "prefix": "cmd:if",
+        "body": [
+            "if ${1:command} (",
+            "\t$0",
+            ")"
+        ]
+    },
+    "cmd if else": {
+        "description": "if else operator",
+        "prefix": "cmd:if-else",
+        "body": [
+            "if ${1:command} (",
+            "\t${2:echo}",
+            ") else (",
+            "\t$0",
+            ")"
+        ]
+    },
+    "cmd for": {
+        "description": "for operator",
+        "prefix": "cmd:for",
+        "body": [
+            "for %%${1:variable} in (${2:list}) do (",
+            "\t$0",
+            ")"
+        ]
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -245,6 +245,18 @@
             "awk '{ gsub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
         ]
     },
+    "trigger": {
+        "description": "trigger definition",
+        "prefix": "trigger",
+        "body": [
+            "on:",
+            "  ${1:event}:",
+            "    branches:",
+            "    - ${2:branch}",
+            "",
+            "  workflow_dispatch:"
+        ]
+    },
     "step": {
         "description": "step definition",
         "prefix": "step",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -249,7 +249,7 @@
         "description": "step or job description",
         "prefix": "description",
         "body": [
-            "${1|Build,Lint,Test|} with `${2:tool}`"
+            "${1|Build,Lint,Test|} with ${2|`,',\"|}${3:tool}$2"
         ]
     },
     "trigger": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -212,21 +212,21 @@
     },
     "sed replace single": {
         "description": "single replacement",
-        "prefix": "sed:single-replacement",
+        "prefix": "sed:replace-first",
         "body": [
             "sed ${1|--regexp-extended,-E|} 's/${2:pattern}/${3:replacement}/' ${4:path/to/file}"
         ]
     },
     "sed replace globally": {
         "description": "global replacement",
-        "prefix": "sed:global-replacement",
+        "prefix": "sed:replace-all",
         "body": [
             "sed ${1|--regexp-extended,-E|} 's/${2:pattern}/${3:replacement}/g' ${4:path/to/file}"
         ]
     },
     "sed transliterate": {
         "description": "transliteration",
-        "prefix": "sed:transliteration",
+        "prefix": "sed:transliterate",
         "body": [
             "sed ${1|--regexp-extended,-E|} 'y/${2:source-characters}/${3:replacement-characters}/g' ${4:path/to/file}"
         ]
@@ -261,14 +261,14 @@
     },
     "awk replace single": {
         "description": "single replacement",
-        "prefix": "awk:single-replacement",
+        "prefix": "awk:replace-first",
         "body": [
             "awk '{ sub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
         ]
     },
     "awk replace globally": {
         "description": "global replacement",
-        "prefix": "awk:global-replacement",
+        "prefix": "awk:replace-all",
         "body": [
             "awk '{ gsub(\"${1:pattern}\", \"${2:replacement}\") }' ${3:path/to/file}"
         ]


### PR DESCRIPTION
- Snippets for workflow operators
- Snippets for Bash, CMD, PowerShell compound commands
- Snippets for sed, awk
- Snippets for commands, triggers, steps, jobs

I didn't provide snippets for functions, as I think when functions are needed it's better to write a separate shell script and just invoke it from workflow.

closes #36 