### PR TITLE
Correct languageservices repo path in bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -17,7 +17,7 @@ root="$(dirname "$repo_root")"
 
 # Clone dependent repos
 echo "Cloning dependent repos..."
-clone_repo https://github.com/github/actions-languageservices "$root"/actions-languageservices
+clone_repo https://github.com/actions/languageservices "$root"/actions-languageservices
 
 
 # Copy workspace files


### PR DESCRIPTION
Clone language services repo from https://github.com/actions/languageservices in bootstrap script