### PR TITLE
Remove newline characters from workflow run names

### DIFF
--- a/src/treeViews/currentBranch.ts
+++ b/src/treeViews/currentBranch.ts
@@ -113,14 +113,10 @@ export class CurrentBranchTreeProvider
     const resp = result.data;
     const runs = resp.workflow_runs;
     // We are removing newlines from workflow names for presentation purposes
-    const runsWithNamesWithNoNewlines = runs.map(run => {
-      if (run.name) {
-        run.name = run.name.replace(/(\r\n|\n|\r)/gm, " ");
-      }
+    for (const run of runs) {
+      run.name = run.name?.replace(/(\r\n|\n|\r)/gm, " ");
+    }
 
-      return run;
-    });
-
-    return this.runNodes(gitHubRepoContext, runsWithNamesWithNoNewlines, true);
+    return this.runNodes(gitHubRepoContext, runs, true);
   }
 }

--- a/src/treeViews/currentBranch.ts
+++ b/src/treeViews/currentBranch.ts
@@ -112,7 +112,15 @@ export class CurrentBranchTreeProvider
 
     const resp = result.data;
     const runs = resp.workflow_runs;
+    // We are removing newlines from workflow names for presentation purposes
+    const runsWithNamesWithNoNewlines = runs.map(run => {
+      if (run.name) {
+        run.name = run.name.replace(/(\r\n|\n|\r)/gm, " ");
+      }
 
-    return this.runNodes(gitHubRepoContext, runs, true);
+      return run;
+    });
+
+    return this.runNodes(gitHubRepoContext, runsWithNamesWithNoNewlines, true);
   }
 }

--- a/src/treeViews/workflows/workflowsRepoNode.ts
+++ b/src/treeViews/workflows/workflowsRepoNode.ts
@@ -36,6 +36,10 @@ export async function getWorkflowNodes(gitHubRepoContext: GitHubRepoContext) {
     workflows.map(async wf => {
       const workflowUri = getWorkflowUri(gitHubRepoContext, wf.path);
       const workflowContext = await getContextStringForWorkflow(workflowUri);
+      const nameWithoutNewlines = wf.name.replace(/(\r\n|\n|\r)/gm, " ");
+
+      // We are removing all newline characters from the workflow name for presentation purposes
+      wf.name = nameWithoutNewlines;
 
       return new WorkflowNode(gitHubRepoContext, wf, workflowContext);
     })


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/49

YAML supports multiline keys. See [this](https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines) StackOverflow for more information on YAML support for multi-line strings. GitHub does not support multiline strings in workflow run names, therefore this change replaces newline characters with a space.

Given this workflow file:

```yaml
name: |
    A
    B
    C
    D
on:
  workflow_dispatch:
jobs:
  do-stuff:
    runs-on: ubuntu-latest
    steps:
      - run: echo "I have run!"
```

Before the change the UI look like this:

<img width="138" alt="Screenshot 2023-04-05 at 11 07 56 AM" src="https://user-images.githubusercontent.com/7937889/230167582-527ede54-b0d1-4c7d-af86-ce08ca36c70b.png">

<img width="165" alt="Screenshot 2023-04-05 at 11 08 19 AM" src="https://user-images.githubusercontent.com/7937889/230167567-79b72a8b-8537-49e2-86d1-5f677add8f07.png">

With the change the UI looks like this:

<img width="165" alt="Screenshot 2023-04-05 at 11 08 49 AM" src="https://user-images.githubusercontent.com/7937889/230167421-1cc13df5-e6c0-4030-a16d-2808696d064f.png">

<img width="165" alt="Screenshot 2023-04-05 at 11 08 44 AM" src="https://user-images.githubusercontent.com/7937889/230167527-e85bcbab-63fb-4ee3-bac5-db0cd13bb6b9.png">
