### PR TITLE
Set all contexts for view upon sign in

### DIFF
--- a/src/commands/signIn.ts
+++ b/src/commands/signIn.ts
@@ -1,12 +1,20 @@
 import * as vscode from "vscode";
 import {getSession} from "../auth/auth";
+import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
+import {getGitHubContext} from "../git/repository";
 
 export function registerSignIn(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("github-actions.sign-in", async () => {
       const session = await getSession(true);
       if (session) {
+        const canReachAPI = await canReachGitHubAPI();
+        const ghContext = await getGitHubContext();
+        const hasGitHubRepos = ghContext && ghContext.repos.length > 0;
+
         await vscode.commands.executeCommand("setContext", "github-actions.signed-in", true);
+        await vscode.commands.executeCommand("setContext", "github-actions.internet-access", canReachAPI);
+        await vscode.commands.executeCommand("setContext", "github-actions.has-repos", hasGitHubRepos);
       }
     })
   );

--- a/src/treeViews/treeViews.ts
+++ b/src/treeViews/treeViews.ts
@@ -25,7 +25,12 @@ export async function initTreeViews(context: vscode.ExtensionContext, store: Run
     vscode.commands.registerCommand("github-actions.explorer.refresh", async () => {
       const canReachAPI = await canReachGitHubAPI();
       await vscode.commands.executeCommand("setContext", "github-actions.internet-access", canReachAPI);
-      if (canReachAPI) {
+
+      const ghContext = await getGitHubContext();
+      const hasGitHubRepos = ghContext && ghContext.repos.length > 0;
+      await vscode.commands.executeCommand("setContext", "github-actions.has-repos", hasGitHubRepos);
+
+      if (canReachAPI && hasGitHubRepos) {
         await workflowTreeProvider.refresh();
         await settingsTreeProvider.refresh();
       }


### PR DESCRIPTION
Set all contexts for view upon sign in and refresh

Fixes:
- https://github.com/github/vscode-github-actions/issues/57
- https://github.com/github/vscode-github-actions/issues/55
- https://github.com/github/vscode-github-actions/issues/93

The problem is that when logging in the context only gets set for the login and there are 3 contexts related to the View (`github-actions.signed-in`, `github-actions.has-repos`, and `github-actions.internet-access `). The view checks for these in `vscode-github-actions/package.json`. 

They are reading for the `when` condition, and there is an issue where if you download the extension, enable it, and THEN you login at that point, that the contexts for repo and internet are not set, so that causes the view not to change.  So the user is actually logged in, but the view isn't triggered to change. 

This change adds two additional checks for `has-repos` and `internet-access` when a user signs in.

![image](https://user-images.githubusercontent.com/7976517/230630778-8132d6af-6d7f-44a7-b60c-6e54cebc4333.png)


Demo of broken state before fix:
![vscodeloginbroken](https://user-images.githubusercontent.com/7976517/230629188-441a5879-9d65-45ba-bb88-60b5f402b732.gif)

Demo of fixed state:
![vscodeloginfixed](https://user-images.githubusercontent.com/7976517/230629192-a196cdd7-1d24-4f6d-a5c4-b680d25beef4.gif)


Co-authored from @KetchupOnMyKetchup and @lrotschy 