### PR TITLE
Add debugger when  using Watch all & Launch extension option

### DIFF
--- a/script/workspace/vscode-github-actions.code-workspace
+++ b/script/workspace/vscode-github-actions.code-workspace
@@ -33,7 +33,8 @@
         "cwd": "${workspaceFolder:vscode-github-actions}",
         "preLaunchTask": "watch",
         "smartStep": true,
-        "sourceMaps": true
+        "sourceMaps": true,
+        "resolveSourceMapLocations": []
       }
     ],
     "compounds": [


### PR DESCRIPTION
Adding `"resolveSourceMapLocations": []` which allows the debugger to be hit when using the Watch all & Launch extension option in the main VS Code extension project.