### PR TITLE
Update workflow file

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -17,11 +17,9 @@ jobs:
           node-version: 16.x
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
-      - run: rm package-lock.json
       - run: npm --no-git-tag-version version 1.0.${{ github.run_number }}
-      - run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm install @actions/languageserver@latest @actions/workflow-parser@latest @actions/expressions@latest @actions/languageservice@latest
+      - run: npm ci
       - run: npm run package
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
We are moving from `npm i` to `npm ci` to have greater control what dependencies are installed.