### PR TITLE
Make pre-prepare run off of hooks 

### DIFF
--- a/.github/workflows/pre-prepare.yml
+++ b/.github/workflows/pre-prepare.yml
@@ -1,14 +1,15 @@
-name: Pre-Prepare
+name: Pull langauge server changes
 
 on:
  workflow_dispatch:
   inputs:
-    pull-langugageserver:
-      description: "Are there changes to language server?"
-      required: true
     target-branch: 
       description: name of the branch that contains the desired changes
       required: true
+  workflow_run:
+    workflows: ["Create release PR"]
+    types:
+      - completed
     
 permissions:
   contents: write

--- a/.github/workflows/pre-prepare.yml
+++ b/.github/workflows/pre-prepare.yml
@@ -6,6 +6,10 @@ on:
     target-branch: 
       description: name of the branch that contains the desired changes
       required: true
+    run: 
+      description: whether or not to run the workflow
+      required: true
+      type: boolean
   workflow_run:
     workflows: ["Create release PR"]
     types:

--- a/.github/workflows/pre-prepare.yml
+++ b/.github/workflows/pre-prepare.yml
@@ -1,15 +1,6 @@
 name: Pull language server changes
 
 on:
- workflow_dispatch:
-  inputs:
-    target-branch: 
-      description: name of the branch that contains the desired changes
-      required: true
-    run: 
-      description: whether or not to run the workflow
-      required: true
-      type: boolean
   workflow_run:
     workflows: ["Create release PR"]
     types:
@@ -35,32 +26,32 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{github.event.inputs.target-branch}} 
-        if: ${{ github.event.inputs.run == 'true' }}}
+          ref: ${{inputs.target-branch}} 
+        if: ${{inputs.run == 'true' }}}
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - name: run npm install
         run: npm install @actions/languageserver@latest @actions/workflow-parser@latest --workspaces=false
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - name: revert changes to package.json
         run: git checkout -- package.json
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - name: debugging
         run: git diff
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - name: run npm i
         run: npm i
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - name: debugging
         run: git diff 
-        if: ${{ github.event.inputs.run == 'true' }}}
+        if: ${{inputs.run == 'true' }}}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with: 
-          branch: ${{github.event.inputs.target-branch}}
-        if: ${{ github.event.inputs.run == 'true' }}}
+          branch: ${{inputs.target-branch}}
+        if: ${{inputs.run == 'true' }}}
           

--- a/.github/workflows/pre-prepare.yml
+++ b/.github/workflows/pre-prepare.yml
@@ -1,4 +1,4 @@
-name: Pull langauge server changes
+name: Pull language server changes
 
 on:
  workflow_dispatch:
@@ -10,6 +10,15 @@ on:
     workflows: ["Create release PR"]
     types:
       - completed
+    inputs:
+      target-branch: 
+        required: true 
+        type: string
+        description: name of the branch that contains the desired changes
+      run: 
+        required: true
+        type: boolean 
+        description: whether or not to run the workflow
     
 permissions:
   contents: write
@@ -23,24 +32,31 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{github.event.inputs.target-branch}} 
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: run npm install
         run: npm install @actions/languageserver@latest @actions/workflow-parser@latest --workspaces=false
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: revert changes to package.json
         run: git checkout -- package.json
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: debugging
         run: git diff
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: run npm i
         run: npm i
+        if: ${{ github.event.inputs.run == 'true' }}}
       - name: debugging
         run: git diff 
+        if: ${{ github.event.inputs.run == 'true' }}}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with: 
           branch: ${{github.event.inputs.target-branch}}
-          
+        if: ${{ github.event.inputs.run == 'true' }}}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,6 @@ jobs:
             --head release/${{ inputs.version }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        outputs:
+          target-branch: release/${{ github.event.inputs.version }}
+          run: ${{ github.event.inputs.update-language-server}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       version:
         required: true
         description: "Version to bump `package.json` to (format: x.y.z)"
+      update-language-server: 
+        required: false
+        description: "Update the language server to the latest version?"
+        type: boolean
+
 
 jobs:
   create-release-pr:


### PR DESCRIPTION
fixes: https://github.com/github/vscode-github-actions/issues/129

Alright, this pr adds a trigger to the `Pull language server changes workflow` that should enable it to run when you create a new PR using the release workflow. To test it properly we will need to bump the version of language sever so the job fully fires. We also need to merge this in so we can test it works at all. Before we do that, I'd appreciate someone looking it over and making sure everything i'm doing makes sense. 

cc: @lrotschy who helped with both iterations of this. 