### PR TITLE
Filter out wikis

### DIFF
--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -155,7 +155,11 @@ export async function getGitHubContext(): Promise<GitHubContext | undefined> {
   try {
     const git = await getGitExtension();
 
-    const protocolInfos = await getGitHubUrls();
+    const allProtocolInfos = await getGitHubUrls();
+
+    // Filter out wiki repositories because the GET call will fail and throw an error
+    const protocolInfos = allProtocolInfos?.filter(info => !info.protocol.repositoryName.match(/\.wiki$/));
+    
     if (!protocolInfos) {
       logDebug("Could not get protocol infos");
       return undefined;
@@ -174,7 +178,7 @@ export async function getGitHubContext(): Promise<GitHubContext | undefined> {
       return await Promise.all(
         protocolInfos.map(async (protocolInfo): Promise<GitHubRepoContext> => {
           logDebug("Getting infos for repository", protocolInfo.url);
-
+          
           const repoInfo = await client.repos.get({
             repo: protocolInfo.protocol.repositoryName,
             owner: protocolInfo.protocol.owner

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -159,7 +159,7 @@ export async function getGitHubContext(): Promise<GitHubContext | undefined> {
 
     // Filter out wiki repositories because the GET call will fail and throw an error
     const protocolInfos = allProtocolInfos?.filter(info => !info.protocol.repositoryName.match(/\.wiki$/));
-    
+
     if (!protocolInfos) {
       logDebug("Could not get protocol infos");
       return undefined;
@@ -178,7 +178,7 @@ export async function getGitHubContext(): Promise<GitHubContext | undefined> {
       return await Promise.all(
         protocolInfos.map(async (protocolInfo): Promise<GitHubRepoContext> => {
           logDebug("Getting infos for repository", protocolInfo.url);
-          
+
           const repoInfo = await client.repos.get({
             repo: protocolInfo.protocol.repositoryName,
             owner: protocolInfo.protocol.owner


### PR DESCRIPTION
Fixes https://github.com/github/vscode-github-actions/issues/111

Before if you have a cloned wiki in your workspace the extension would not load. This line in repository.ts was failing for wiki repositories:  `const repo = git && git.getRepository(protocolInfo.workspaceUri);` A wiki is a special kind of repo that ends with `.wiki`, so it was included in the list of repos for the workspace, but the call doesn't work as it does for normal repositories.

link to broken line: https://github.com/github/vscode-github-actions/blob/0ff1a0385ffb1dfbecd798d3c2d5a5c04b927f6a/src/git/repository.ts#L183

Before:

![wiki-before](https://github.com/github/vscode-github-actions/assets/21186402/82e17a6e-1255-490a-8eee-7b8b39fc4db7)

After:

![wiki-after](https://github.com/github/vscode-github-actions/assets/21186402/d5bdee8a-299d-4372-a5e5-70e54b0ac58a)

Co-authored by: @KetchupOnMyKetchup 