### PR TITLE
Automatically detect a remote that is not called "origin" so that users don't have to enter the remote name manually

### DIFF
--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -70,7 +70,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
         let remote = r.state.remotes.filter(remote => remote.name === remoteName);
 
         // If "origin" does not exist, automatically get another remote
-        if (remote === undefined || remote.length === 0) {
+        if (r.state.remotes.length !== 0 && remote.length === 0) {
           remote = [r.state.remotes[0]];
         }
 

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -66,9 +66,16 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
         logDebug("Find `origin` remote for repository", r.rootUri.path);
         await r.status();
 
-        const originRemote = r.state.remotes.filter(remote => remote.name === remoteName);
-        if (originRemote.length > 0 && originRemote[0].pushUrl?.indexOf("github.com") !== -1) {
-          const url = originRemote[0].pushUrl;
+        // Try to get "origin" remote first
+        let remote = r.state.remotes.filter(remote => remote.name === remoteName);
+
+        // If "origin" does not exist, automatically get another remote
+        if (remote === undefined || remote.length === 0) {
+          remote = [r.state.remotes[0]];
+        }
+
+        if (remote.length > 0 && remote[0].pushUrl?.indexOf("github.com") !== -1) {
+          const url = remote[0].pushUrl;
 
           return {
             workspaceUri: r.rootUri,


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/121

If remote cannot find "origin", then automatically try to get the next remote regardless of name so that the user does not have to enter it manually.

The reason this did not work before is that `origin` was keyed into the `getRemoteName()` method:
![image](https://github.com/github/vscode-github-actions/assets/7976517/9a00512a-ce60-4402-86ec-7427bc559818)

And the filter on line 70 was only checking for `origin`:
![image](https://github.com/github/vscode-github-actions/assets/7976517/6fb06903-9c2f-4480-8c49-9b3901dee95c)

So if it did not find it, then it just returned undefined and the user had to set the remote manually.  I think that it makes sense to search for origin first, but then to automatically grab any other existing remote if possible. 

Before fix:
![image](https://github.com/github/vscode-github-actions/assets/7976517/da81cd72-3e29-4796-9ebb-ba7912b14dae)

After fix:
![nonoriginworking](https://github.com/github/vscode-github-actions/assets/7976517/54795724-3907-45fb-86d5-127c3c75f5a9)



Co-authored by @lrotschy