### PR TITLE
Add a globe icon to workflow steps that links to the GitHub.com specific step

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
       {
         "command": "github-actions.workflow.logs",
         "category": "GitHub Actions",
-        "title": "View logs",
+        "title": "View job logs",
         "when": "viewItem =~ /job/",
         "icon": {
           "dark": "resources/icons/dark/logs.svg",
@@ -150,7 +150,7 @@
       {
         "command": "github-actions.step.logs",
         "category": "GitHub Actions",
-        "title": "View logs",
+        "title": "View step logs",
         "when": "viewItem =~ /step/",
         "icon": "$(globe)"
       },

--- a/package.json
+++ b/package.json
@@ -152,10 +152,7 @@
         "category": "GitHub Actions",
         "title": "View logs",
         "when": "viewItem =~ /step/",
-        "icon": {
-          "dark": "resources/icons/dark/logs.svg",
-          "light": "resources/icons/light/logs.svg"
-        }
+        "icon": "$(globe)"
       },
       {
         "command": "github-actions.workflow.run.rerun",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,16 @@
         }
       },
       {
+        "command": "github-actions.step.logs",
+        "category": "GitHub Actions",
+        "title": "View logs",
+        "when": "viewItem =~ /step/",
+        "icon": {
+          "dark": "resources/icons/dark/logs.svg",
+          "light": "resources/icons/light/logs.svg"
+        }
+      },
+      {
         "command": "github-actions.workflow.run.rerun",
         "category": "GitHub Actions",
         "title": "Rerun workflow run",
@@ -364,6 +374,11 @@
           "when": "viewItem =~ /job/ && viewItem =~ /completed/"
         },
         {
+          "command": "github-actions.step.logs",
+          "group": "inline",
+          "when": "viewItem =~ /step/ && viewItem =~ /completed/"
+        },
+        {
           "command": "github-actions.workflow.run.cancel",
           "when": "viewItem =~ /run/ && viewItem =~ /cancelable/"
         },
@@ -436,6 +451,10 @@
         },
         {
           "command": "github-actions.workflow.logs",
+          "when": "false"
+        },
+        {
+          "command": "github-actions.step.logs",
           "when": "false"
         },
         {

--- a/src/commands/openWorkflowStepLogs.ts
+++ b/src/commands/openWorkflowStepLogs.ts
@@ -1,0 +1,55 @@
+import * as vscode from "vscode";
+import {GitHubRepoContext} from "../git/repository";
+import {updateDecorations} from "../logs/formatProvider";
+import {getLogInfo} from "../logs/logInfo";
+import {buildLogURI} from "../logs/scheme";
+import {WorkflowJob} from "../store/WorkflowJob";
+import { WorkflowStep } from "../model";
+
+export interface OpenWorkflowStepLogsCommandArgs {
+  gitHubRepoContext: GitHubRepoContext;
+  job: WorkflowJob;
+  step: WorkflowStep;
+}
+
+export function registerOpenWorkflowStepLogs(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("github-actions.step.logs", async (args: OpenWorkflowStepLogsCommandArgs) => {
+      const gitHubRepoContext = args.gitHubRepoContext;
+      const job = args.job;
+      const step = args.step;
+
+      const uri = buildLogURI(
+        `%23${job.job.run_id} - ${job.job.name}`,
+        gitHubRepoContext.owner,
+        gitHubRepoContext.name,
+        job.job.id
+      );
+
+      const doc = await vscode.workspace.openTextDocument(uri);
+      const editor = await vscode.window.showTextDocument(doc, {
+        preview: false
+      });
+
+      const logInfo = getLogInfo(uri);
+      if (!logInfo) {
+        throw new Error("Could not get log info");
+      }
+
+      const section = logInfo.sections.find(s => s.name === step.name);
+      const startLine = section ? section.start : 0;
+      const endLine = section ? section.end : 0;
+
+
+      const stepInfo = {
+        updatedLogLines: logInfo["updatedLogLines"].slice(startLine, endLine),
+        sections: logInfo["sections"].filter(s => s.name === step.name),
+        styleFormats: logInfo["styleFormats"].filter(s => s.line >= startLine && s.line <= endLine)
+      };
+
+
+      // Custom formatting after the editor has been opened
+      updateDecorations(editor, stepInfo);
+    })
+  );
+}

--- a/src/commands/openWorkflowStepLogs.ts
+++ b/src/commands/openWorkflowStepLogs.ts
@@ -1,12 +1,7 @@
 import * as vscode from "vscode";
-import {WorkflowJob, WorkflowStep} from "../model";
+import {WorkflowStepNode} from "../treeViews/workflows/workflowStepNode";
 
-export interface WorkflowStepCommandArgs {
-  job: WorkflowJob;
-  step: WorkflowStep;
-}
-
-// export type WorkflowStepCommandArgs = Pick<WorkflowJobNode, "job">;
+type WorkflowStepCommandArgs = Pick<WorkflowStepNode, "job" | "step" | "gitHubRepoContext">;
 
 export function registerOpenWorkflowStepLogs(context: vscode.ExtensionContext) {
   context.subscriptions.push(

--- a/src/commands/openWorkflowStepLogs.ts
+++ b/src/commands/openWorkflowStepLogs.ts
@@ -1,17 +1,12 @@
 import * as vscode from "vscode";
-import {WorkflowJob, WorkflowRun} from "../model";
-import {GitHubRepoContext} from "../git/repository";
-import {integer} from "vscode-languageclient";
-import {WorkflowRunCommandArgs, WorkflowRunNode} from "../treeViews/shared/workflowRunNode";
-import {WorkflowJobNode} from "../treeViews/shared/workflowJobNode";
+import {WorkflowJob, WorkflowStep} from "../model";
 
-// export interface OpenWorkflowStepLogsCommandArgs {
-//   gitHubRepoContext: GitHubRepoContext;
-//   job: WorkflowJob;
-//   run: WorkflowRun;
-// }
+export interface WorkflowStepCommandArgs {
+  job: WorkflowJob;
+  step: WorkflowStep;
+}
 
-export type WorkflowStepCommandArgs = Pick<WorkflowJobNode, "job">;
+// export type WorkflowStepCommandArgs = Pick<WorkflowJobNode, "job">;
 
 export function registerOpenWorkflowStepLogs(context: vscode.ExtensionContext) {
   context.subscriptions.push(

--- a/src/commands/openWorkflowStepLogs.ts
+++ b/src/commands/openWorkflowStepLogs.ts
@@ -1,55 +1,32 @@
 import * as vscode from "vscode";
+import {WorkflowJob, WorkflowRun} from "../model";
 import {GitHubRepoContext} from "../git/repository";
-import {updateDecorations} from "../logs/formatProvider";
-import {getLogInfo} from "../logs/logInfo";
-import {buildLogURI} from "../logs/scheme";
-import {WorkflowJob} from "../store/WorkflowJob";
-import { WorkflowStep } from "../model";
+import {integer} from "vscode-languageclient";
+import {WorkflowRunCommandArgs, WorkflowRunNode} from "../treeViews/shared/workflowRunNode";
+import {WorkflowJobNode} from "../treeViews/shared/workflowJobNode";
 
-export interface OpenWorkflowStepLogsCommandArgs {
-  gitHubRepoContext: GitHubRepoContext;
-  job: WorkflowJob;
-  step: WorkflowStep;
-}
+// export interface OpenWorkflowStepLogsCommandArgs {
+//   gitHubRepoContext: GitHubRepoContext;
+//   job: WorkflowJob;
+//   run: WorkflowRun;
+// }
+
+export type WorkflowStepCommandArgs = Pick<WorkflowJobNode, "job">;
 
 export function registerOpenWorkflowStepLogs(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("github-actions.step.logs", async (args: OpenWorkflowStepLogsCommandArgs) => {
-      const gitHubRepoContext = args.gitHubRepoContext;
-      const job = args.job;
-      const step = args.step;
+    vscode.commands.registerCommand("github-actions.step.logs", async (args: WorkflowStepCommandArgs) => {
+      const job = args.job.job;
+      let url = job.html_url ?? "";
+      const stepName = args.step.name;
 
-      const uri = buildLogURI(
-        `%23${job.job.run_id} - ${job.job.name}`,
-        gitHubRepoContext.owner,
-        gitHubRepoContext.name,
-        job.job.id
-      );
+      const index = job.steps && job.steps.findIndex(step => step.name === stepName) + 1;
 
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const editor = await vscode.window.showTextDocument(doc, {
-        preview: false
-      });
-
-      const logInfo = getLogInfo(uri);
-      if (!logInfo) {
-        throw new Error("Could not get log info");
+      if (url && index) {
+        url = url + "#step:" + index.toString() + ":1";
       }
 
-      const section = logInfo.sections.find(s => s.name === step.name);
-      const startLine = section ? section.start : 0;
-      const endLine = section ? section.end : 0;
-
-
-      const stepInfo = {
-        updatedLogLines: logInfo["updatedLogLines"].slice(startLine, endLine),
-        sections: logInfo["sections"].filter(s => s.name === step.name),
-        styleFormats: logInfo["styleFormats"].filter(s => s.line >= startLine && s.line <= endLine)
-      };
-
-
-      // Custom formatting after the editor has been opened
-      updateDecorations(editor, stepInfo);
+      await vscode.env.openExternal(vscode.Uri.parse(url));
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import {getSession} from "./auth/auth";
 import {registerCancelWorkflowRun} from "./commands/cancelWorkflowRun";
 import {registerOpenWorkflowFile} from "./commands/openWorkflowFile";
 import {registerOpenWorkflowJobLogs} from "./commands/openWorkflowJobLogs";
+import {registerOpenWorkflowStepLogs} from "./commands/openWorkflowStepLogs";
 import {registerOpenWorkflowRun} from "./commands/openWorkflowRun";
 import {registerPinWorkflow} from "./commands/pinWorkflow";
 import {registerReRunWorkflowRun} from "./commands/rerunWorkflowRun";
@@ -71,6 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerOpenWorkflowRun(context);
   registerOpenWorkflowFile(context);
   registerOpenWorkflowJobLogs(context);
+  registerOpenWorkflowStepLogs(context);
   registerTriggerWorkflowRun(context);
   registerReRunWorkflowRun(context);
   registerCancelWorkflowRun(context);


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/139

Issue:
- Users with hundreds of steps would like an easier way to get to the steps.  
- User request "I wish the tree nodes for individual steps had a View logs icon just like the nodes for jobs.
- Users want some action to happen when they click on steps.
- We used to have a way to jump to the place in the steps but that was problematic and removed - https://github.com/github/vscode-github-actions/commit/b2380f06150020c2fed3ae016f3b00ca5aa70eaa.  We wanted to try to show just the step logs specifically in VS Code, but that solution would require better API support because currently there is no way to exactly correlate step names.


Fixes:
- Add a globe icon (indicating an external site) which links to the specific step.  
- Change tooltip text from "View logs" to be more specific "View job logs" and "View step logs"


Demo:
![viewlogsdemo](https://github.com/github/vscode-github-actions/assets/7976517/e31a951f-4402-4e45-82ea-4e5810c80c0d)

Additional info:
Talked to @andrewakim about this solution here: https://github.slack.com/archives/C03QVCCH1FZ/p1683051030748249
![image](https://github.com/github/vscode-github-actions/assets/7976517/95e95143-08cd-4436-bb79-41a68204f70b)



Co-authored by @lrotschy 