### PR TITLE
Addd note in README to use lock file if `npm i` fails

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,9 @@ npm i
 npm run build -ws
 ```
 
+**Note**: We have included a `package-lock.json` in `script/workspace`. If packages cannot be installed correctly re-run `script/boostrap` and run `npm ci` to
+get working packages.
+
 ## Make changes
 
 1. Open the workspace in VS Code `File -> Open Workspace from File...`: `/workspaces/vscode-github-actions.code-workspace`

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ npm i
 npm run build -ws
 ```
 
-**Note**: We have included a `package-lock.json` in `script/workspace`. If packages cannot be installed correctly re-run `script/boostrap` and run `npm ci` to
+**Note**: We have included a `package-lock.json` in `script/workspace`. If `npm run build -ws` fails because packages are not installed correctly with `nmp i`, re-run `script/boostrap` and run `npm ci` to
 get working packages.
 
 ## Make changes


### PR DESCRIPTION
We aren't checking in the `package-lock.json` file for the workspace. This poses a problem if new versions of packages are broken. To mitigate this unlikely scenario we have included in a `package-lock.json` file in the `script` directory that can be used.