### PR TITLE
Change name of NPM package from vscode-github-actions to @github/vscode-github-actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vscode-github-actions",
+  "name": "@github/vscode-github-actions",
   "version": "0.25.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-github-actions",
+      "name": "@github/vscode-github-actions",
       "version": "0.25.6",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-github-actions",
+  "name": "@github/vscode-github-actions",
   "displayName": "GitHub Actions",
   "publisher": "github",
   "icon": "resources/logo.png",


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/153

Issue:
- Someone created a fake npm package using our official name here: https://www.npmjs.com/package/vscode-github-actions
- We get a console warning when we run `npm audit fix --force`. Before the fix we got this warning:
![image](https://github.com/github/vscode-github-actions/assets/7976517/ee1216cb-0ae7-4c8f-b94b-a107057247e8)



Fix
- No longer get console warning when we run `npm audit fix --force`
![image](https://github.com/github/vscode-github-actions/assets/7976517/4add668f-92fa-42e2-9ab3-2f3f3e412aee)
- If we re-name it to something that is within a regulated name like @github then we won't have someone take up our name with malicious intent to trick users.
- Change name of NPM package from vscode-github-actions to @github/vscode-github-actions in `package.json`
- Ran `update-package-locks.sh` to align `package-lock.json` file.

Tested app to make sure everything still works after name change:
![renameappstillworks](https://github.com/github/vscode-github-actions/assets/7976517/03d6557f-672d-490b-9786-5655c6ef62de)
