### PR TITLE
Enable GitHub Enterprise Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
           "description": "The name of the repository's git remote that points to GitHub",
           "default": "origin",
           "scope": "window"
+        },
+        "github-actions.use-enterprise": {
+          "type": "boolean",
+          "markdownDescription": "If this is set to true, use the auth provider for the GitHub Enterprise URL configured in `github-enterprise.uri`",
+          "default": false,
+          "scope": "window"
         }
       }
     },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,6 +8,6 @@ export function getClient(token: string): Octokit {
   return new Octokit({
     auth: token,
     userAgent: userAgent,
-    baseUrl: `${getGitHubApiUri()}`
+    baseUrl: getGitHubApiUri()
   });
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,11 +1,13 @@
 import {Octokit} from "@octokit/rest";
 import {version} from "../../package.json";
+import {getGitHubApiUri} from "../configuration/configuration";
 
 export const userAgent = `VS Code GitHub Actions (${version})`;
 
 export function getClient(token: string): Octokit {
   return new Octokit({
     auth: token,
-    userAgent: userAgent
+    userAgent: userAgent,
+    baseUrl: `${getGitHubApiUri()}`
   });
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import {isUseEnterprise} from "../configuration/configuration";
+import {useEnterprise} from "../configuration/configuration";
 
 const AUTH_PROVIDER_ID = "github";
 const AUTH_PROVIDER_ID_ENTERPRISE = "github-enterprise";
@@ -69,7 +69,7 @@ async function getSessionInternal(
     typeof createOrForceMessage === "string"
       ? {forceNewSession: {detail: createOrForceMessage}}
       : {createIfNone: createOrForceMessage};
-  const authProviderId = isUseEnterprise() ? AUTH_PROVIDER_ID_ENTERPRISE : AUTH_PROVIDER_ID;
+  const authProviderId = useEnterprise() ? AUTH_PROVIDER_ID_ENTERPRISE : AUTH_PROVIDER_ID;
   return await vscode.authentication.getSession(authProviderId, getScopes(), options);
 }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
+import {isUseEnterprise} from "../configuration/configuration";
 
 const AUTH_PROVIDER_ID = "github";
+const AUTH_PROVIDER_ID_ENTERPRISE = "github-enterprise";
 const DEFAULT_SCOPES = ["repo", "workflow"];
 
 let signInPrompted = false;
@@ -67,7 +69,8 @@ async function getSessionInternal(
     typeof createOrForceMessage === "string"
       ? {forceNewSession: {detail: createOrForceMessage}}
       : {createIfNone: createOrForceMessage};
-  return await vscode.authentication.getSession(AUTH_PROVIDER_ID, getScopes(), options);
+  const authProviderId = isUseEnterprise() ? AUTH_PROVIDER_ID_ENTERPRISE : AUTH_PROVIDER_ID;
+  return await vscode.authentication.getSession(authProviderId, getScopes(), options);
 }
 
 function getScopes(): string[] {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -7,17 +7,17 @@ const DEFAULT_GITHUB_API = "https://api.github.com";
 
 export function initConfiguration(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration(e => {
+    vscode.workspace.onDidChangeConfiguration(async e => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
       } else if (
         e.affectsConfiguration(getSettingsKey("use-enterprise")) ||
-        (isUseEnterprise() &&
+        (useEnterprise() &&
           (e.affectsConfiguration("github-enterprise.uri") || e.affectsConfiguration(getSettingsKey("remote-name"))))
       ) {
-        updateLanguageServerApiUrl(context);
+        await updateLanguageServerApiUrl(context);
         resetGitHubContext();
-        vscode.commands.executeCommand("github-actions.explorer.refresh");
+        await vscode.commands.executeCommand("github-actions.explorer.refresh");
       }
     })
   );
@@ -64,18 +64,18 @@ export function getRemoteName(): string {
   return getConfiguration().get<string>(getSettingsKey("remote-name"), "origin");
 }
 
-export function isUseEnterprise(): boolean {
+export function useEnterprise(): boolean {
   return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false);
 }
 
 export function getGitHubApiUri(): string {
-  if (!isUseEnterprise()) return DEFAULT_GITHUB_API;
+  if (!useEnterprise()) return DEFAULT_GITHUB_API;
   const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "");
   return base === DEFAULT_GITHUB_API ? base : `${base}/api/v3`;
 }
 
-function updateLanguageServerApiUrl(context: vscode.ExtensionContext) {
-  deactivateLanguageServer();
+async function updateLanguageServerApiUrl(context: vscode.ExtensionContext) {
+  await deactivateLanguageServer();
 
-  initLanguageServer(context);
+  await initLanguageServer(context);
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,12 +1,16 @@
 import * as vscode from "vscode";
+import {deactivateLanguageServer} from "../workflow/languageServer";
 
 const settingsKey = "github-actions";
+const DEFAULT_GITHUB_API = "https://api.github.com";
 
 export function initConfiguration(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
+      } else if (e.affectsConfiguration(getSettingsKey("use-enterprise"))) {
+        updateLanguageServerApiUrl();
       }
     })
   );
@@ -51,4 +55,20 @@ export function pinnedWorkflowsRefreshInterval(): number {
 
 export function getRemoteName(): string {
   return getConfiguration().get<string>(getSettingsKey("remote-name"), "origin");
+}
+
+export function isUseEnterprise(): boolean {
+  return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false);
+}
+
+export function getGitHubApiUri(): string {
+  if (!isUseEnterprise()) return DEFAULT_GITHUB_API;
+  const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "");
+  return base === DEFAULT_GITHUB_API ? base : `${base}/api/v3`;
+}
+
+function updateLanguageServerApiUrl() {
+  // deactivateLanguageServer();
+  // TODO: restart language server with new URL configured
+  throw new Error("Can't yet change the api url parameter without restart.");
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import {deactivateLanguageServer} from "../workflow/languageServer";
+import {deactivateLanguageServer, initLanguageServer} from "../workflow/languageServer";
 
 const settingsKey = "github-actions";
 const DEFAULT_GITHUB_API = "https://api.github.com";
@@ -9,8 +9,11 @@ export function initConfiguration(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
-      } else if (e.affectsConfiguration(getSettingsKey("use-enterprise"))) {
-        updateLanguageServerApiUrl();
+      } else if (
+        e.affectsConfiguration(getSettingsKey("use-enterprise")) ||
+        e.affectsConfiguration("github-enterprise.uri")
+      ) {
+        updateLanguageServerApiUrl(context);
       }
     })
   );
@@ -67,8 +70,8 @@ export function getGitHubApiUri(): string {
   return base === DEFAULT_GITHUB_API ? base : `${base}/api/v3`;
 }
 
-function updateLanguageServerApiUrl() {
-  // deactivateLanguageServer();
-  // TODO: restart language server with new URL configured
-  throw new Error("Can't yet change the api url parameter without restart.");
+function updateLanguageServerApiUrl(context: vscode.ExtensionContext) {
+  deactivateLanguageServer();
+
+  initLanguageServer(context);
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import {deactivateLanguageServer, initLanguageServer} from "../workflow/languageServer";
+import {resetGitHubContext} from "../git/repository";
 
 const settingsKey = "github-actions";
 const DEFAULT_GITHUB_API = "https://api.github.com";
@@ -11,9 +12,12 @@ export function initConfiguration(context: vscode.ExtensionContext) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
       } else if (
         e.affectsConfiguration(getSettingsKey("use-enterprise")) ||
-        e.affectsConfiguration("github-enterprise.uri")
+        (isUseEnterprise() &&
+          (e.affectsConfiguration("github-enterprise.uri") || e.affectsConfiguration(getSettingsKey("remote-name"))))
       ) {
         updateLanguageServerApiUrl(context);
+        resetGitHubContext();
+        vscode.commands.executeCommand("github-actions.explorer.refresh");
       }
     })
   );

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -4,7 +4,7 @@ import {Octokit} from "@octokit/rest";
 import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
 import {handleSamlError} from "../api/handleSamlError";
 import {getSession} from "../auth/auth";
-import {getRemoteName} from "../configuration/configuration";
+import {getRemoteName, isUseEnterprise} from "../configuration/configuration";
 import {Protocol} from "../external/protocol";
 import {logDebug, logError} from "../log";
 import {API, GitExtension, RefType, RepositoryState} from "../typings/git";
@@ -74,7 +74,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote = [r.state.remotes[0]];
         }
 
-        if (remote.length > 0 && remote[0].pushUrl?.indexOf("github.com") !== -1) {
+        if (remote.length > 0 && (remote[0].pushUrl?.indexOf("github.com") !== -1 || isUseEnterprise())) {
           const url = remote[0].pushUrl;
 
           return {

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -4,11 +4,12 @@ import {Octokit} from "@octokit/rest";
 import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
 import {handleSamlError} from "../api/handleSamlError";
 import {getSession} from "../auth/auth";
-import {getRemoteName, isUseEnterprise} from "../configuration/configuration";
+import {getRemoteName, useEnterprise} from "../configuration/configuration";
 import {Protocol} from "../external/protocol";
 import {logDebug, logError} from "../log";
 import {API, GitExtension, RefType, RepositoryState} from "../typings/git";
 import {RepositoryPermission, getRepositoryPermission} from "./repository-permissions";
+import {getGitHubApiUri} from "../configuration/configuration";
 
 interface GitHubUrls {
   workspaceUri: vscode.Uri;
@@ -74,7 +75,11 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote = [r.state.remotes[0]];
         }
 
-        if (remote.length > 0 && (remote[0].pushUrl?.indexOf("github.com") !== -1 || isUseEnterprise())) {
+        if (
+          remote.length > 0 &&
+          (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
+            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1))
+        ) {
           const url = remote[0].pushUrl;
 
           return {

--- a/src/workflow/languageServer.ts
+++ b/src/workflow/languageServer.ts
@@ -11,7 +11,7 @@ import {userAgent} from "../api/api";
 import {getSession} from "../auth/auth";
 import {getGitHubContext} from "../git/repository";
 import {WorkflowSelector} from "./documentSelector";
-import {getGitHubApiUri, isUseEnterprise} from "../configuration/configuration";
+import {getGitHubApiUri, useEnterprise} from "../configuration/configuration";
 
 let client: BaseLanguageClient;
 
@@ -27,7 +27,7 @@ export async function initLanguageServer(context: vscode.ExtensionContext) {
   const initializationOptions: InitializationOptions = {
     sessionToken: session?.accessToken,
     userAgent: userAgent,
-    githubApiUrl: isUseEnterprise() ? getGitHubApiUri() : undefined,
+    gitHubApiUrl: useEnterprise() ? getGitHubApiUri() : undefined,
     repos: ghContext?.repos.map(repo => ({
       id: repo.id,
       owner: repo.owner,

--- a/src/workflow/languageServer.ts
+++ b/src/workflow/languageServer.ts
@@ -11,6 +11,7 @@ import {userAgent} from "../api/api";
 import {getSession} from "../auth/auth";
 import {getGitHubContext} from "../git/repository";
 import {WorkflowSelector} from "./documentSelector";
+import {getGitHubApiUri, isUseEnterprise} from "../configuration/configuration";
 
 let client: BaseLanguageClient;
 
@@ -26,6 +27,7 @@ export async function initLanguageServer(context: vscode.ExtensionContext) {
   const initializationOptions: InitializationOptions = {
     sessionToken: session?.accessToken,
     userAgent: userAgent,
+    githubApiUrl: isUseEnterprise() ? getGitHubApiUri() : undefined,
     repos: ghContext?.repos.map(repo => ({
       id: repo.id,
       owner: repo.owner,


### PR DESCRIPTION
This pull request implements #12 
Depends on https://github.com/actions/languageservices/pull/43

For GitHub Enterprise Server users, the plugin has the issue of not recognizing actions and shared workflows hosted only there. This pull request adds an option to use the already available authentication provider for GitHub Enterprise Server (official VSCode GitHub plugin).