### PR TITLE
Fix variables window for enterprise server versions below 3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/languageserver": "*",
         "@actions/workflow-parser": "*",
+        "@octokit/plugin-enterprise-server": "^12.1.0",
         "@octokit/rest": "^19.0.7",
         "@vscode/vsce": "^2.19.0",
         "buffer": "^6.0.3",
@@ -1625,6 +1626,33 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
       "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+    },
+    "node_modules/@octokit/plugin-enterprise-server": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-12.1.0.tgz",
+      "integrity": "sha512-Cx05I2M17sw6wmi+C2kdI9jRPFgaIYPi30UkByqp6/ke2oXKSuzvJw5/E4EXGrV6E8sD065gIk0XnUjr8C+aYQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-enterprise-server/node_modules/@octokit/openapi-types": {
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.2.tgz",
+      "integrity": "sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw=="
+    },
+    "node_modules/@octokit/plugin-enterprise-server/node_modules/@octokit/types": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.2.tgz",
+      "integrity": "sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==",
+      "dependencies": {
+        "@octokit/openapi-types": "^17.1.2"
+      }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.0.0",
@@ -11423,6 +11451,29 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
       "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+    },
+    "@octokit/plugin-enterprise-server": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-12.1.0.tgz",
+      "integrity": "sha512-Cx05I2M17sw6wmi+C2kdI9jRPFgaIYPi30UkByqp6/ke2oXKSuzvJw5/E4EXGrV6E8sD065gIk0XnUjr8C+aYQ==",
+      "requires": {
+        "@octokit/types": "^9.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "17.1.2",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.2.tgz",
+          "integrity": "sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw=="
+        },
+        "@octokit/types": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.2.tgz",
+          "integrity": "sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==",
+          "requires": {
+            "@octokit/openapi-types": "^17.1.2"
+          }
+        }
+      }
     },
     "@octokit/plugin-paginate-rest": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/languageserver": "*",
         "@actions/workflow-parser": "*",
-        "@octokit/plugin-enterprise-server": "^12.1.0",
         "@octokit/rest": "^19.0.7",
         "@vscode/vsce": "^2.19.0",
         "buffer": "^6.0.3",
@@ -1626,33 +1625,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
       "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
-    },
-    "node_modules/@octokit/plugin-enterprise-server": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-12.1.0.tgz",
-      "integrity": "sha512-Cx05I2M17sw6wmi+C2kdI9jRPFgaIYPi30UkByqp6/ke2oXKSuzvJw5/E4EXGrV6E8sD065gIk0XnUjr8C+aYQ==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-enterprise-server/node_modules/@octokit/openapi-types": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.2.tgz",
-      "integrity": "sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw=="
-    },
-    "node_modules/@octokit/plugin-enterprise-server/node_modules/@octokit/types": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.2.tgz",
-      "integrity": "sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.1.2"
-      }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.0.0",
@@ -11451,29 +11423,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
       "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
-    },
-    "@octokit/plugin-enterprise-server": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-server/-/plugin-enterprise-server-12.1.0.tgz",
-      "integrity": "sha512-Cx05I2M17sw6wmi+C2kdI9jRPFgaIYPi30UkByqp6/ke2oXKSuzvJw5/E4EXGrV6E8sD065gIk0XnUjr8C+aYQ==",
-      "requires": {
-        "@octokit/types": "^9.0.0"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.1.2",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.2.tgz",
-          "integrity": "sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw=="
-        },
-        "@octokit/types": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.2.tgz",
-          "integrity": "sha512-9BjDxjgQIvCjNWZsbqyH5QC2Yni16oaE6xL+8SUBMzcYPF4TGQBXGA97Cl3KceK9mwiNMb1mOYCz6FbCCLEL+g==",
-          "requires": {
-            "@octokit/openapi-types": "^17.1.2"
-          }
-        }
-      }
     },
     "@octokit/plugin-paginate-rest": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
           "description": "The name of the repository's git remote that points to GitHub",
           "default": "origin",
           "scope": "window"
+        },
+        "github-actions.use-enterprise": {
+          "type": "boolean",
+          "markdownDescription": "If this is set to true, use the auth provider for the GitHub Enterprise URL configured in `github-enterprise.uri`",
+          "default": false,
+          "scope": "window"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -562,7 +562,6 @@
   "dependencies": {
     "@actions/languageserver": "*",
     "@actions/workflow-parser": "*",
-    "@octokit/plugin-enterprise-server": "^12.1.0",
     "@octokit/rest": "^19.0.7",
     "@vscode/vsce": "^2.19.0",
     "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -562,6 +562,7 @@
   "dependencies": {
     "@actions/languageserver": "*",
     "@actions/workflow-parser": "*",
+    "@octokit/plugin-enterprise-server": "^12.1.0",
     "@octokit/rest": "^19.0.7",
     "@vscode/vsce": "^2.19.0",
     "buffer": "^6.0.3",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,13 +1,21 @@
 import {Octokit} from "@octokit/rest";
+import {enterpriseServer34} from "@octokit/plugin-enterprise-server";
 import {version} from "../../package.json";
-import {getGitHubApiUri} from "../configuration/configuration";
+import {getGitHubApiUri, isUseEnterprise} from "../configuration/configuration";
 
 export const userAgent = `VS Code GitHub Actions (${version})`;
 
+export const OctokitES = Octokit.plugin(enterpriseServer34);
+
 export function getClient(token: string): Octokit {
-  return new Octokit({
-    auth: token,
-    userAgent: userAgent,
-    baseUrl: `${getGitHubApiUri()}`
-  });
+  return isUseEnterprise()
+    ? new OctokitES({
+        auth: token,
+        userAgent: userAgent,
+        baseUrl: `${getGitHubApiUri()}`
+      })
+    : new Octokit({
+        auth: token,
+        userAgent: userAgent
+      });
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,11 +1,13 @@
 import {Octokit} from "@octokit/rest";
 import {version} from "../../package.json";
+import {getGitHubApiUri} from "../configuration/configuration";
 
 export const userAgent = `VS Code GitHub Actions (${version})`;
 
 export function getClient(token: string): Octokit {
   return new Octokit({
     auth: token,
-    userAgent: userAgent
+    userAgent: userAgent,
+    baseUrl: `${getGitHubApiUri()}`
   });
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,21 +1,13 @@
 import {Octokit} from "@octokit/rest";
-import {enterpriseServer34} from "@octokit/plugin-enterprise-server";
 import {version} from "../../package.json";
-import {getGitHubApiUri, isUseEnterprise} from "../configuration/configuration";
+import {getGitHubApiUri} from "../configuration/configuration";
 
 export const userAgent = `VS Code GitHub Actions (${version})`;
 
-export const OctokitES = Octokit.plugin(enterpriseServer34);
-
 export function getClient(token: string): Octokit {
-  return isUseEnterprise()
-    ? new OctokitES({
-        auth: token,
-        userAgent: userAgent,
-        baseUrl: `${getGitHubApiUri()}`
-      })
-    : new Octokit({
-        auth: token,
-        userAgent: userAgent
-      });
+  return new Octokit({
+    auth: token,
+    userAgent: userAgent,
+    baseUrl: `${getGitHubApiUri()}`
+  });
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
+import {isUseEnterprise} from "../configuration/configuration";
 
 const AUTH_PROVIDER_ID = "github";
+const AUTH_PROVIDER_ID_ENTERPRISE = "github-enterprise";
 const DEFAULT_SCOPES = ["repo", "workflow"];
 
 let signInPrompted = false;
@@ -67,7 +69,8 @@ async function getSessionInternal(
     typeof createOrForceMessage === "string"
       ? {forceNewSession: {detail: createOrForceMessage}}
       : {createIfNone: createOrForceMessage};
-  return await vscode.authentication.getSession(AUTH_PROVIDER_ID, getScopes(), options);
+  const authProviderId = isUseEnterprise() ? AUTH_PROVIDER_ID_ENTERPRISE : AUTH_PROVIDER_ID;
+  return await vscode.authentication.getSession(authProviderId, getScopes(), options);
 }
 
 function getScopes(): string[] {

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,12 +1,16 @@
 import * as vscode from "vscode";
+import {deactivateLanguageServer} from "../workflow/languageServer";
 
 const settingsKey = "github-actions";
+const DEFAULT_GITHUB_API = "https://api.github.com";
 
 export function initConfiguration(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
+      } else if (e.affectsConfiguration(getSettingsKey("use-enterprise"))) {
+        updateLanguageServerApiUrl();
       }
     })
   );
@@ -51,4 +55,20 @@ export function pinnedWorkflowsRefreshInterval(): number {
 
 export function getRemoteName(): string {
   return getConfiguration().get<string>(getSettingsKey("remote-name"), "origin");
+}
+
+export function isUseEnterprise(): boolean {
+  return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false);
+}
+
+export function getGitHubApiUri(): string {
+  if (!isUseEnterprise()) return DEFAULT_GITHUB_API;
+  const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "");
+  return base === DEFAULT_GITHUB_API ? base : `${base}/api/v3`;
+}
+
+function updateLanguageServerApiUrl() {
+  // deactivateLanguageServer();
+  // TODO: restart language server with new URL configured
+  throw new Error("Can't yet change the api url parameter without restart.");
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import {deactivateLanguageServer} from "../workflow/languageServer";
+import {deactivateLanguageServer, initLanguageServer} from "../workflow/languageServer";
 
 const settingsKey = "github-actions";
 const DEFAULT_GITHUB_API = "https://api.github.com";
@@ -9,8 +9,11 @@ export function initConfiguration(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration(getSettingsKey("workflows.pinned"))) {
         pinnedWorkflowsChangeHandlers.forEach(h => h());
-      } else if (e.affectsConfiguration(getSettingsKey("use-enterprise"))) {
-        updateLanguageServerApiUrl();
+      } else if (
+        e.affectsConfiguration(getSettingsKey("use-enterprise")) ||
+        e.affectsConfiguration("github-enterprise.uri")
+      ) {
+        updateLanguageServerApiUrl(context);
       }
     })
   );
@@ -67,8 +70,8 @@ export function getGitHubApiUri(): string {
   return base === DEFAULT_GITHUB_API ? base : `${base}/api/v3`;
 }
 
-function updateLanguageServerApiUrl() {
-  // deactivateLanguageServer();
-  // TODO: restart language server with new URL configured
-  throw new Error("Can't yet change the api url parameter without restart.");
+function updateLanguageServerApiUrl(context: vscode.ExtensionContext) {
+  deactivateLanguageServer();
+
+  initLanguageServer(context);
 }

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -296,5 +296,8 @@ export function getCurrentBranch(state: RepositoryState | undefined): string | u
 }
 
 export function hasVariables(context: GitHubContext): boolean {
-  return !!context.enterpriseServerVersion && context.enterpriseServerVersion >= "3.8.0";
+  if (!context.enterpriseServerVersion) return true;
+  const split = context.enterpriseServerVersion.split(".");
+  if (split.length < 2) return true;
+  return +split[0] >= 3 && +split[1] >= 8;
 }

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -4,7 +4,7 @@ import {Octokit} from "@octokit/rest";
 import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
 import {handleSamlError} from "../api/handleSamlError";
 import {getSession} from "../auth/auth";
-import {getRemoteName} from "../configuration/configuration";
+import {getRemoteName, isUseEnterprise} from "../configuration/configuration";
 import {Protocol} from "../external/protocol";
 import {logDebug, logError} from "../log";
 import {API, GitExtension, RefType, RepositoryState} from "../typings/git";
@@ -74,7 +74,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote = [r.state.remotes[0]];
         }
 
-        if (remote.length > 0 && remote[0].pushUrl?.indexOf("github.com") !== -1) {
+        if (remote.length > 0 && (remote[0].pushUrl?.indexOf("github.com") !== -1 || isUseEnterprise())) {
           const url = remote[0].pushUrl;
 
           return {

--- a/src/treeViews/settings.ts
+++ b/src/treeViews/settings.ts
@@ -42,10 +42,10 @@ export class SettingsTreeProvider implements vscode.TreeDataProvider<SettingsExp
     if (!element) {
       if (gitHubContext.repos.length > 0) {
         if (gitHubContext.repos.length == 1) {
-          return getSettingNodes(gitHubContext.repos[0]);
+          return getSettingNodes(gitHubContext.repos[0], gitHubContext);
         }
 
-        return gitHubContext.repos.map(r => new SettingsRepoNode(r));
+        return gitHubContext.repos.map(r => new SettingsRepoNode(r, gitHubContext));
       }
     }
 

--- a/src/treeViews/settings/settingsRepoNode.ts
+++ b/src/treeViews/settings/settingsRepoNode.ts
@@ -1,32 +1,34 @@
 import * as vscode from "vscode";
 
 import {EnvironmentsNode} from "./environmentsNode";
-import {GitHubRepoContext} from "../../git/repository";
+import {GitHubContext, GitHubRepoContext, hasVariables} from "../../git/repository";
 import {hasWritePermission} from "../../git/repository-permissions";
 import {SecretsNode} from "./secretsNode";
 import {SettingsExplorerNode} from "./types";
 import {VariablesNode} from "./variablesNode";
 
 export class SettingsRepoNode extends vscode.TreeItem {
-  constructor(public readonly gitHubRepoContext: GitHubRepoContext) {
+  constructor(public readonly gitHubRepoContext: GitHubRepoContext, public readonly gitHubContext: GitHubContext) {
     super(gitHubRepoContext.name, vscode.TreeItemCollapsibleState.Collapsed);
 
     this.contextValue = "settings-repo";
   }
 
   getSettings(): SettingsExplorerNode[] {
-    return getSettingNodes(this.gitHubRepoContext);
+    return getSettingNodes(this.gitHubRepoContext, this.gitHubContext);
   }
 }
 
-export function getSettingNodes(gitHubContext: GitHubRepoContext): SettingsExplorerNode[] {
+export function getSettingNodes(repoContext: GitHubRepoContext, gitHubContext: GitHubContext): SettingsExplorerNode[] {
   const nodes: SettingsExplorerNode[] = [];
 
-  nodes.push(new EnvironmentsNode(gitHubContext));
+  nodes.push(new EnvironmentsNode(repoContext));
 
-  if (hasWritePermission(gitHubContext.permissionLevel)) {
-    nodes.push(new SecretsNode(gitHubContext));
-    nodes.push(new VariablesNode(gitHubContext));
+  if (hasWritePermission(repoContext.permissionLevel)) {
+    nodes.push(new SecretsNode(repoContext));
+    if (hasVariables(gitHubContext)) {
+      nodes.push(new VariablesNode(repoContext));
+    }
   }
 
   return nodes;

--- a/src/workflow/languageServer.ts
+++ b/src/workflow/languageServer.ts
@@ -11,6 +11,7 @@ import {userAgent} from "../api/api";
 import {getSession} from "../auth/auth";
 import {getGitHubContext} from "../git/repository";
 import {WorkflowSelector} from "./documentSelector";
+import {getGitHubApiUri, isUseEnterprise} from "../configuration/configuration";
 
 let client: BaseLanguageClient;
 
@@ -26,6 +27,7 @@ export async function initLanguageServer(context: vscode.ExtensionContext) {
   const initializationOptions: InitializationOptions = {
     sessionToken: session?.accessToken,
     userAgent: userAgent,
+    githubApiUrl: isUseEnterprise() ? getGitHubApiUri() : undefined,
     repos: ghContext?.repos.map(repo => ({
       id: repo.id,
       owner: repo.owner,


### PR DESCRIPTION
The variables node will not be loaded now if GitHub enterprise is being used and the version of the GitHub Enterprise Server is lower than 3.8.0.

Depends on #183.