### PR TITLE
Improve Windows Dev Experience: fix npm commands (cross-env package), fix Source Control Repos, and document all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ These are one time installations required to be able to test your changes locall
 
 1. Install [Node.js](https://nodejs.org/en/download/) for your platform
 1. Install [VS Code](https://code.visualstudio.com/download) for your platform
-1. Install the dependencies. From the repository root run:
+1. Install the dependencies. From the repository root (`~/vscode`) run:
 
 ```bash
 npm i
@@ -70,6 +70,14 @@ npm run watch
 1. Setup `Watch all & Launch Extension (workspace)` under Debug and hit the green button (this will automatically run `npm watch` for you and monitor for changes).
 1. Make change
 1. Hit the refresh button in the debugger window to reload the extension in the development host
+
+## npm commands
+
+For the below make sure that you are in the `vscode-github-actions` directory of your local repo first.
+
+```bash
+cd vscode-github-actions
+```
 
 ### Running tests
 
@@ -120,7 +128,7 @@ npm run package
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository
-1. Configure and install the dependencies: `npm i`
+1. Configure and install the dependencies (in the main root folder `~/vscode`): `npm i`
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Make your change, add tests, and make sure the tests and linter still pass
 1. Push to your fork and [submit a pull request][pr]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,25 @@ These are one time installations required to be able to test your changes locall
 npm i
 ```
 
-## Making & testing changes
+### Dev loop & Testing changes
 
 The extension is written in TypeScript and built using [webpack](https://webpack.js.org/).
+
+1. Go to the Debug tab.
+    1. Hit `Watch all & Launch Extension (workspace)` if you want to work on the main VS Code extension like the left sidebar and the UI for the extension.
+    1. Hit `Watch & Launch Extension + language-server (workspace)` If you want to work on the language services code and want to debug and work on the hover, syntax highlighting, and other functionality within the Workflow files.
+        * This will attach to an instance of the language server running on port `6010`
+1. Hit the green button (this will automatically run `npm watch` for you and monitor for changes) which will open a local version of the extension using the _extension development host_.
+1. Make changes
+1. Hit the refresh button in the debugger window to reload the extension in the development host
+
+## npm commands
+
+For the below make sure that you are in the `vscode-github-actions` directory of your local repo first.
+
+```bash
+cd vscode-github-actions
+```
 
 ### Build
 
@@ -55,28 +71,6 @@ Or to watch for changes and automatically rebuild every time on save:
 
 ```bash
 npm run watch
-```
-
-### Testing changes
-
-1. Open the repository in VS Code
-1. Run one of the debug targets:
-  * "Watch & Launch extension" - watch extension files, compile as necessary, and run the extension using the _extension development host_
-  * "Attach to Language-Server" - attach to an instance of the language server running on port `6010`
-  * "Run Web Extension in VS Code" - run the [web version](https://code.visualstudio.com/api/extension-guides/web-extensions) of the extension
-
-### Dev loop
-
-1. Setup `Watch all & Launch Extension (workspace)` under Debug and hit the green button (this will automatically run `npm watch` for you and monitor for changes).
-1. Make change
-1. Hit the refresh button in the debugger window to reload the extension in the development host
-
-## npm commands
-
-For the below make sure that you are in the `vscode-github-actions` directory of your local repo first.
-
-```bash
-cd vscode-github-actions
 ```
 
 ### Running tests
@@ -124,6 +118,10 @@ npm run format
 ```bash
 npm run package
 ```
+
+### Run Web Extension
+
+"Run Web Extension in VS Code" - run the [web version](https://code.visualstudio.com/api/extension-guides/web-extensions) of the extension
 
 ## VS Code Source Control Repositories
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ These are one time installations required to be able to test your changes locall
 npm i
 ```
 
-### Dev loop & Testing changes
+## Dev loop & Testing changes
 
 The extension is written in TypeScript and built using [webpack](https://webpack.js.org/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ These are one time installations required to be able to test your changes locall
 
 1. Install [Node.js](https://nodejs.org/en/download/) for your platform
 1. Install [VS Code](https://code.visualstudio.com/download) for your platform
-1. Install the dependencies. From the repository root (`~/vscode`) run:
+1. Install the dependencies. From the repository root run:
 
 ```bash
 npm i
@@ -134,7 +134,7 @@ If you don't see `vscode-github-actions` and `languageservices`, please go to `P
 ## Submitting a pull request
 
 1. [Fork][fork] and clone the repository
-1. Configure and install the dependencies (in the main root folder `~/vscode`): `npm i`
+1. Configure and install the dependencies (in the repository root folder): `npm i`
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Make your change, add tests, and make sure the tests and linter still pass
 1. Push to your fork and [submit a pull request][pr]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The extension is written in TypeScript and built using [webpack](https://webpack
 
 1. Go to the Debug tab.
     1. Hit `Watch all & Launch Extension (workspace)` if you want to work on the main VS Code extension like the left sidebar and the UI for the extension.
-    1. Hit `Watch & Launch Extension + language-server (workspace)` If you want to work on the language services code and want to debug and work on the hover, syntax highlighting, and other functionality within the Workflow files.
+    1. Hit `Watch & Launch Extension + language-server (workspace)` if you want to work on the language services code and want to debug and work on the hover, syntax highlighting, and other functionality within the Workflow files.
         * This will attach to an instance of the language server running on port `6010`
 1. Hit the green button (this will automatically run `npm watch` for you and monitor for changes) which will open a local version of the extension using the _extension development host_.
 1. Make changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,9 @@ These are one time installations required to be able to test your changes locall
 1. Install [Node.js](https://nodejs.org/en/download/) for your platform
 1. Install [VS Code](https://code.visualstudio.com/download) for your platform
 1. Install the dependencies. From the repository root run:
+
 ```bash
-$ npm i
+npm i
 ```
 
 ## Making & testing changes
@@ -47,13 +48,13 @@ The extension is written in TypeScript and built using [webpack](https://webpack
 Build changes (one time):
 
 ```bash
-$ npm run build
+npm run build
 ```
 
 Or to watch for changes and automatically rebuild every time on save:
 
 ```bash
-$ npm run watch
+npm run watch
 ```
 
 ### Testing changes
@@ -65,33 +66,35 @@ $ npm run watch
   * "Run Web Extension in VS Code" - run the [web version](https://code.visualstudio.com/api/extension-guides/web-extensions) of the extension
 
 ### Dev loop
-1. Setup `Watch all & Launch Extension` under Debug and hit the green button
-1. `npm run watch`
+
+1. Setup `Watch all & Launch Extension (workspace)` under Debug and hit the green button (this will automatically run `npm watch` for you and monitor for changes).
 1. Make change
 1. Hit the refresh button in the debugger window to reload the extension in the development host
 
 ### Running tests
 
+_Note: We added `cross-env` to our package.json so that this works on both Mac and Windows._
+
 ```bash
-$ npm test
+npm test
 ```
 
 Or to watch for changes and run tests:
 
 ```bash
-$ npm run test-watch
+npm run test-watch
 ```
 
 ### Lint
 
 ```bash
-$ npm run lint
+npm run lint
 ```
 
 Run linter and fix errors as possible:
 
 ```bash
-$ npm run lint-fix
+npm run lint-fix
 ```
 
 ### Format
@@ -99,19 +102,19 @@ $ npm run lint-fix
 Check formatting with [prettier](https://prettier.io/):
 
 ```bash
-$ npm run format-check
+npm run format-check
 ```
 
 Run prettier and automatically format:
 
 ```bash
-$ npm run format
+npm run format
 ```
 
 ### Package the extension
 
 ```bash
-$ npm run package
+npm run package
 ```
 
 ## Submitting a pull request
@@ -134,7 +137,6 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 - [GitHub Help](https://help.github.com)
-
 
 [bug issues]: https://github.com/github/vscode-github-actions/labels/bug
 [feature request issues]: https://github.com/github/vscode-github-actions/labels/enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ npm i
 
 ## Dev loop & Testing changes
 
-The extension is written in TypeScript and built using [webpack](https://webpack.js.org/).
+The extension is written in TypeScript and built using [webpack](https://webpack.js.org/). The dev loop steps and commands have been tested on both Mac and Windows.
 
 1. Go to the Debug tab.
     1. Hit `Watch all & Launch Extension (workspace)` if you want to work on the main VS Code extension like the left sidebar and the UI for the extension.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ The extension is written in TypeScript and built using [webpack](https://webpack
 1. Hit the green button (this will automatically run `npm watch` for you and monitor for changes) which will open a local version of the extension using the _extension development host_.
 1. Make changes
 1. Hit the refresh button in the debugger window to reload the extension in the development host
+![image](https://github.com/github/vscode-github-actions/assets/7976517/8dbd3d75-f447-483e-b7e7-ffec3ccd7562)
+
 
 ## npm commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ The extension is written in TypeScript and built using [webpack](https://webpack
     1. Hit `Watch & Launch Extension + language-server (workspace)` If you want to work on the language services code and want to debug and work on the hover, syntax highlighting, and other functionality within the Workflow files.
         * This will attach to an instance of the language server running on port `6010`
 1. Hit the green button (this will automatically run `npm watch` for you and monitor for changes) which will open a local version of the extension using the _extension development host_.
-1. Make changes
-1. Hit the refresh button in the debugger window to reload the extension in the development host
+1. Make changes.
+1. To get new changes, hit the refresh button in the debugger window to reload the extension in the development host.  _If you don't see the changes, wait long enough for the `npm watch` terminal to rebuild and then try hitting the green button again._
 ![image](https://github.com/github/vscode-github-actions/assets/7976517/8dbd3d75-f447-483e-b7e7-ffec3ccd7562)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^5.40.0",
         "@typescript-eslint/parser": "^5.40.0",
         "@vscode/test-web": "*",
+        "cross-env": "^7.0.3",
         "eslint": "^8.25.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -3476,6 +3477,24 @@
       "integrity": "sha512-M1VdV3hpBAsd1Zzvqcvf63wgDpcwCuS4WiNEVFpJ0s33MGO2sVDTfswYq0EPypCmESrCzmgL8h68DTzJuSDbVA==",
       "bin": {
         "cronstrue": "bin/cli.js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -12918,6 +12937,15 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.26.0.tgz",
       "integrity": "sha512-M1VdV3hpBAsd1Zzvqcvf63wgDpcwCuS4WiNEVFpJ0s33MGO2sVDTfswYq0EPypCmESrCzmgL8h68DTzJuSDbVA=="
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -526,9 +526,9 @@
     "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. .",
     "lint": "eslint . --ext .ts",
     "lint-fix": "eslint . --ext .ts --fix",
-    "format": "prettier --write '**/*.ts'",
-    "format-check": "prettier --check '**/*.ts'",
-    "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest",
+    "format": "prettier --write \"**/*.ts\"",
+    "format-check": "prettier --check \"**/*.ts\"",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest",
     "test-watch": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --watch"
   },
   "devDependencies": {
@@ -539,6 +539,7 @@
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
     "@vscode/test-web": "*",
+    "cross-env": "^7.0.3",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
Resolves https://github.com/github/vscode-github-actions/issues/89

--

Fix so that `npm` commands to work in Windows:
1. Add `cross-env` package to vscode main project 
    - Note though this package is `Public Archive`, it is still being [actively maintained](https://github.com/kentcdodds/cross-env) "NOTICE: cross-env still works well, but is in maintenance mode. No new features will be added, only serious and common-case bugs will be fixed, and it will only be kept up-to-date with Node.js over time."
    - https://github.com/kentcdodds/cross-env/issues/257
2. Escape with slashes in `package.json`: `format`, `format-check`, and `test`

Updates to [Contributing.md doc](https://github.com/github/vscode-github-actions/blob/ketchup/windowsDevExperience/CONTRIBUTING.md
)
1. Reorganize and rewrite the Dev loop & Testing changes section to be more clear
2. Note use of `cross-env` package
3. Removing $ from commands to make copy/paste easier and indicate it works on Windows as well
4. Add specific notes about which directory to run `npm` commands
5. Add instructions and screenshot for adding both repos to Source Control Repositories

Fixed Source Control Repositories (before it only showed vscode-github-actions and not language services), figured out from [this issue](https://github.com/microsoft/vscode/issues/173226):
![image](https://github.com/github/vscode-github-actions/assets/7976517/402ba447-78e2-449e-9651-219e77b27be8)



<details>
  <summary>Screenshots from Windows BEFORE changes (broken state): </summary>

![image](https://github.com/github/vscode-github-actions/assets/7976517/44edfd37-c934-44d2-a867-5145733bf8e6)

</details>

<details>
  <summary>Screenshots from Windows to show that it works still after changes: </summary>

![image](https://github.com/github/vscode-github-actions/assets/7976517/326f1538-5067-4785-a348-4c0017cca187)

</details>


<details>
  <summary>Screenshots from Mac to show that it works still after changes:</summary>

![image](https://github.com/github/vscode-github-actions/assets/7976517/29abfb0c-16a6-483d-bfa9-0e0b9de5512a)

![image](https://github.com/github/vscode-github-actions/assets/7976517/9b8f276e-88db-4389-8cce-8d237205c29a)

![image](https://github.com/github/vscode-github-actions/assets/7976517/798ce3aa-3a66-43d5-a2b2-99517f71b12a)

![image](https://github.com/github/vscode-github-actions/assets/7976517/433a332b-515e-41df-b472-cf09452a94a9)

</details>