### PR TITLE
Fix preview run

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -20,6 +20,10 @@ jobs:
       - run: npm --no-git-tag-version version 1.0.${{ github.run_number }}
       - run: npm install @actions/languageserver@latest @actions/workflow-parser@latest @actions/expressions@latest @actions/languageservice@latest
       - run: npm ci
+      - name: create a package.json without scoped name
+        run: |
+          cp package.json package.json.real
+          sed --regexp-extended '/"name"\s*:/ s#@[a-zA-Z\\-]+/##' package.json.real > package.json
       - run: npm run package
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The Preview run has been broken since we switched to a scoped name in https://github.com/github/vscode-github-actions/pull/172

Pulls in fix from [publish.yml](https://github.com/github/vscode-github-actions/blob/a15973742b21a52880a69dc96cdd780926ad3c5e/.github/workflows/publish.yml#L87)

Passing run with working artifact: https://github.com/github/vscode-github-actions/actions/runs/5591233452