### PR TITLE
Update publish.yml to publish to OpenVSX

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,3 +147,20 @@ jobs:
           pat: ${{ secrets.PUBLISHER_KEY }}
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ./vscode-github-actions-${{ needs.release.outputs.version }}.vsix
+          
+  open-vsx-publish:
+    name: Publish to Open VSX Registry
+    needs: release
+    environment: publish-open-vsx
+    runs-on: ubuntu-latest
+    env:
+      OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: vscode-github-actions-${{ needs.release.outputs.version }}.vsix
+
+      - name: Publish to Registry
+        run: |
+          npx ovsx publish -p $OPEN_VSX_TOKEN *.vsix


### PR DESCRIPTION
closes https://github.com/github/vscode-github-actions/issues/73

As per  @aeisenberg's existing flow for the CodeQL extension we can add a step to our workflow to publish to openVSX, once this is approved i'll create the environment and the token and our next release will be published to openVSX