### PR TITLE
Include workspace in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@ registries:
     token: ${{secrets.DEPENDABOT_TOKEN}}
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories: 
+      - "/"
+      - "script/workspace"
     schedule:
       interval: "weekly"
     registries:


### PR DESCRIPTION
Test: include workspace in dependabot config to help stay on top of security findings