### PR TITLE
Sanitize input URL

### DIFF
--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -75,18 +75,18 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote = [r.state.remotes[0]];
         }
 
-        if (
-          remote.length > 0 &&
-          (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
-            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1))
-        ) {
-          const url = remote[0].pushUrl;
+        if (remote.length > 0 && remote[0].pushUrl) {
+          const host = new URL(remote[0].pushUrl).host;
+          const apiUri = new URL(getGitHubApiUri()).host;
+          if (host === "github.com" || (useEnterprise() && host === apiUri)) {
+            const url = remote[0].pushUrl;
 
-          return {
-            workspaceUri: r.rootUri,
-            url,
-            protocol: new Protocol(url as string)
-          };
+            return {
+              workspaceUri: r.rootUri,
+              url,
+              protocol: new Protocol(url as string)
+            };
+          }
         }
 
         logDebug(`Remote "${remoteName}" not found, skipping repository`);

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -84,7 +84,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
             return {
               workspaceUri: r.rootUri,
               url,
-              protocol: new Protocol(url as string)
+              protocol: new Protocol(url)
             };
           }
         }


### PR DESCRIPTION
When checking for the remote, we do not sanitize the URL, meaning that we may treat a non-github.com remote URL as a valid URL. This PR sanitizes the input URL to ensure that we only return a valid GitHub URL or GHES URL.

Addresses https://github.com/github/vscode-github-actions/security/code-scanning/1