### PR TITLE
Skip release and publish workflow in forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ on:
         required: true
 jobs:
   check-version-change:
+    if: ${{ github.repository_owner == 'github' }}
+
     outputs:
       changed: ${{ steps.check-version.outputs.result }}
 


### PR DESCRIPTION
This PR makes the `.github/workflows/publish.yml` workflow being skipped in forks.

Currently when conditions meet, that workflow would create a new release and publish the extension, both in the root repository and in its forks.

Since the publishing jobs need secretes, in most cases they will fail in forks and makes some noice to owners of forks.

Example runs of `publish.yml` workflow
- Before, failed
  https://github.com/muzimuzhi/vscode-github-actions/actions/runs/10319890306
- After, skipped
  https://github.com/muzimuzhi/vscode-github-actions/actions/runs/10368765663