### PR TITLE
Update color regex

### DIFF
--- a/src/logs/model.ts
+++ b/src/logs/model.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-control-regex
-const ansiColorRegex = /\u001b\[(\d+;?)+m/gm;
+const ansiColorRegex = /\u001b\[(\d+;)*\d+m/gm;
 const groupMarker = "##[group]";
 
 import {Parser, IStyle} from "./parser";


### PR DESCRIPTION
Updating regex for detecting log color codes to address https://github.com/github/vscode-github-actions/security/code-scanning/2

Tested locally with a few different logs with different colored lines. It matched my test cases as expected
<img width="508" alt="example logs. the word sleep is blue" src="https://github.com/user-attachments/assets/f774ab58-7616-47f7-a15d-d4e465fe6392">
