### PR TITLE
Revert "Sanitize input URL"

### DIFF
--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -75,18 +75,18 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote = [r.state.remotes[0]];
         }
 
-        if (remote.length > 0 && remote[0].pushUrl) {
-          const host = new URL(remote[0].pushUrl).host;
-          const apiUri = new URL(getGitHubApiUri()).host;
-          if (host === "github.com" || (useEnterprise() && host === apiUri)) {
-            const url = remote[0].pushUrl;
+        if (
+          remote.length > 0 &&
+          (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
+            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1))
+        ) {
+          const url = remote[0].pushUrl;
 
-            return {
-              workspaceUri: r.rootUri,
-              url,
-              protocol: new Protocol(url)
-            };
-          }
+          return {
+            workspaceUri: r.rootUri,
+            url,
+            protocol: new Protocol(url as string)
+          };
         }
 
         logDebug(`Remote "${remoteName}" not found, skipping repository`);


### PR DESCRIPTION
Reverts github/vscode-github-actions#366

There is a bug when using SSH URLs, so reverting this until I have time to look into a bug fix so it does not get inadvertently released.