### PR TITLE
Update elliptic version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "dayjs": "^1.11.7",
+        "elliptic": "6.5.7",
         "libsodium-wrappers": "^0.7.10",
         "path-browserify": "^1.0.1",
         "ssh-config": "^3.0.0",
@@ -3883,9 +3884,10 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -12602,7 +12604,7 @@
         "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.5",
+        "elliptic": "6.5.7",
         "hash-base": "~3.0",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.7",
@@ -12931,7 +12933,7 @@
       "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.5.3"
+        "elliptic": "6.5.7"
       },
       "dependencies": {
         "bn.js": {
@@ -13230,9 +13232,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -568,6 +568,7 @@
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
     "dayjs": "^1.11.7",
+    "elliptic": "6.5.7",
     "libsodium-wrappers": "^0.7.10",
     "path-browserify": "^1.0.1",
     "ssh-config": "^3.0.0",
@@ -577,5 +578,13 @@
     "util": "^0.12.1",
     "uuid": "^3.3.3",
     "vscode-languageclient": "^8.0.2"
+  },
+  "overrides": {
+    "browserify-sign": {
+      "elliptic": "6.5.7"
+    },
+    "create-ecdh": {
+      "elliptic": "6.5.7"
+    }
   }
 }


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/security/dependabot/26
Closes https://github.com/github/vscode-github-actions/security/dependabot/24
Closes https://github.com/github/vscode-github-actions/security/dependabot/25

Dependabot was unable to update the version.
Dependency graph: https://github.com/github/vscode-github-actions/network/updates
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/2871380c-6f58-4afb-8767-f4562d924799">

I added overrides for the packages using an older version of elliptic (or specifying that the version we are using is compatible with an older version), deleted node-modules, and ran `npm install`.
<img width="780" alt="image" src="https://github.com/user-attachments/assets/8aed60a7-0b26-4bfb-a3f2-898f4e01ffe2">

