### PR TITLE
Autofix: help me

### DIFF
--- a/src/commands/triggerWorkflowRun.ts
+++ b/src/commands/triggerWorkflowRun.ts
@@ -127,11 +127,25 @@ export function registerTriggerWorkflowRun(context: vscode.ExtensionContext) {
           }
 
           if (event_type) {
+            const client_payload = await vscode.window.showInputBox({
+              prompt: "Enter client_payload as JSON (optional)",
+              value: "{}"
+            });
+
+            let parsedClientPayload = {};
+            if (client_payload) {
+              try {
+                parsedClientPayload = JSON.parse(client_payload);
+              } catch (error) {
+                return vscode.window.showErrorMessage(`Invalid JSON for client_payload: ${(error as Error)?.message}`);
+              }
+            }
+
             await gitHubRepoContext.client.repos.createDispatchEvent({
               owner: gitHubRepoContext.owner,
               repo: gitHubRepoContext.name,
               event_type,
-              client_payload: {}
+              client_payload: parsedClientPayload
             });
 
             vscode.window.setStatusBarMessage(`GitHub Actions: Repository event '${event_type}' dispatched`, 2000);


### PR DESCRIPTION
I have updated the `triggerWorkflowRun` function in the `src/commands/triggerWorkflowRun.ts` file to include support for `client_payload` when triggering a repository_dispatch event. This allows users to provide additional data when dispatching the event, which can be useful for passing parameters to the workflow. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission