### PR TITLE
Add instructions for cloning the repository using gh CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Be more confident when authoring and modifying workflows. Find errors before com
 1. Open a GitHub repository.
 1. You will be able to utilize the syntax features in Workflow files, and you can find the GitHub Actions icon on the left navigation to manage your Workflows.
 
+### Cloning the Repository
+
+To clone the repository using the `gh` CLI, run the following command:
+
+```sh
+gh repo clone github/vscode-github-actions
+```
 
 ## Supported Features
 


### PR DESCRIPTION
Add instructions for cloning the repository using the `gh` CLI to the `README.md`.

* **Cloning the Repository**: Add a new section under "Getting started" titled "Cloning the Repository".
* **Instructions**: Include step-by-step instructions for using the `gh` CLI to clone the repository: `gh repo clone github/vscode-github-actions`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/github/vscode-github-actions/pull/440?shareId=b29961f5-467a-4429-a00a-98d88ed09893).