### PR TITLE
Fix ghe.com compatibility

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -68,6 +68,16 @@ export function useEnterprise(): boolean {
   return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false);
 }
 
+export function getGithubUri(): string {
+  const apiUri = getGitHubApiUri();
+
+  if (apiUri === DEFAULT_GITHUB_API || apiUri.endsWith(".ghe.com")) {
+    return apiUri.replace(/^(https?):\/\/api\./, "$1://");
+  }
+
+  return apiUri.replace(/\/api\/v3$/, "");
+}
+
 export function getGitHubApiUri(): string {
   if (!useEnterprise()) return DEFAULT_GITHUB_API;
   const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "");
@@ -76,7 +86,7 @@ export function getGitHubApiUri(): string {
   }
 
   if (base.endsWith(".ghe.com")) {
-    return `api.${base}`;
+    return base.replace(/^(https?):\/\//, "$1://api.");
   } else {
     return `${base}/api/v3`;
   }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -68,16 +68,6 @@ export function useEnterprise(): boolean {
   return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false);
 }
 
-export function getGithubUri(): string {
-  const apiUri = getGitHubApiUri();
-
-  if (apiUri === DEFAULT_GITHUB_API || apiUri.endsWith(".ghe.com")) {
-    return apiUri.replace(/^(https?):\/\/api\./, "$1://");
-  }
-
-  return apiUri.replace(/\/api\/v3$/, "");
-}
-
 export function getGitHubApiUri(): string {
   if (!useEnterprise()) return DEFAULT_GITHUB_API;
   const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "");

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -4,12 +4,11 @@ import {Octokit} from "@octokit/rest";
 import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
 import {handleSamlError} from "../api/handleSamlError";
 import {getSession} from "../auth/auth";
-import {getRemoteName, useEnterprise} from "../configuration/configuration";
+import {getGithubUri, getRemoteName, useEnterprise} from "../configuration/configuration";
 import {Protocol} from "../external/protocol";
 import {logDebug, logError} from "../log";
 import {API, GitExtension, RefType, RepositoryState} from "../typings/git";
 import {RepositoryPermission, getRepositoryPermission} from "./repository-permissions";
-import {getGitHubApiUri} from "../configuration/configuration";
 
 interface GitHubUrls {
   workspaceUri: vscode.Uri;
@@ -78,7 +77,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
         if (
           remote.length > 0 &&
           (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
-            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1))
+            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGithubUri()).host) !== -1))
         ) {
           const url = remote[0].pushUrl;
 

--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -4,7 +4,7 @@ import {Octokit} from "@octokit/rest";
 import {canReachGitHubAPI} from "../api/canReachGitHubAPI";
 import {handleSamlError} from "../api/handleSamlError";
 import {getSession} from "../auth/auth";
-import {getGithubUri, getRemoteName, useEnterprise} from "../configuration/configuration";
+import {getGitHubApiUri, getRemoteName, useEnterprise} from "../configuration/configuration";
 import {Protocol} from "../external/protocol";
 import {logDebug, logError} from "../log";
 import {API, GitExtension, RefType, RepositoryState} from "../typings/git";
@@ -77,7 +77,8 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
         if (
           remote.length > 0 &&
           (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
-            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGithubUri()).host) !== -1))
+            (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1) ||
+            remote[0].pushUrl?.indexOf(".ghe.com") !== -1)
         ) {
           const url = remote[0].pushUrl;
 


### PR DESCRIPTION
Fixes: #457

Fixes the extension compatibility with Github Enterprise Cloud instances on `<company>.ghe.com`.

There are two issues I found that needed to be fixed. One was the generation of the API URI, which incorrectly prepended `api.` to the protocol rather than the hostname. Second, when comparing the push URL of a remote with the host of the GHE API host it wouldn't match since the remote does not use the API subdomain.