### PR TITLE
Expression grammar improvements

### DIFF
--- a/language/syntaxes/expressions.tmGrammar.json
+++ b/language/syntaxes/expressions.tmGrammar.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:source.github-actions-workflow",
   "patterns": [
     {
-      "include": "#expression"
+      "include": "#inline-expression"
     },
     {
       "include": "#block-if-expression"
@@ -13,29 +13,14 @@
     }
   ],
   "repository": {
-    "expression": {
+    "inline-expression": {
       "match": "[|-]?\\$\\{\\{(.*?)\\}\\}",
       "name": "meta.embedded.block.github-actions-expression",
       "captures": {
         "1": {
           "patterns": [
             {
-              "include": "#function-call"
-            },
-            {
-              "include": "#context"
-            },
-            {
-              "include": "#string"
-            },
-            {
-              "include": "#number"
-            },
-            {
-              "include": "#boolean"
-            },
-            {
-              "include": "#null"
+              "include": "#expression"
             }
           ]
         }
@@ -83,22 +68,7 @@
           "end": "^(?!\\1|\\s*$)",
           "patterns": [
             {
-              "include": "#function-call"
-            },
-            {
-              "include": "#context"
-            },
-            {
-              "include": "#string"
-            },
-            {
-              "include": "#number"
-            },
-            {
-              "include": "#boolean"
-            },
-            {
-              "include": "#null"
+              "include": "#expression"
             }
           ]
         }
@@ -118,26 +88,33 @@
         "2": {
           "patterns": [
             {
-              "include": "#function-call"
-            },
-            {
-              "include": "#context"
-            },
-            {
-              "include": "#string"
-            },
-            {
-              "include": "#number"
-            },
-            {
-              "include": "#boolean"
-            },
-            {
-              "include": "#null"
+              "include": "#expression"
             }
           ]
         }
       }
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#function-call"
+        },
+        {
+          "include": "#context"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#boolean"
+        },
+        {
+          "include": "#null"
+        }
+      ]
     },
     "function-call": {
       "patterns": [

--- a/language/syntaxes/expressions.tmGrammar.json
+++ b/language/syntaxes/expressions.tmGrammar.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:source.github-actions-workflow",
   "patterns": [
     {
-      "include": "#inline-expression"
+      "include": "#block-inline-expression"
     },
     {
       "include": "#block-if-expression"
@@ -13,18 +13,15 @@
     }
   ],
   "repository": {
-    "inline-expression": {
-      "match": "[|-]?\\$\\{\\{(.*?)\\}\\}",
+    "block-inline-expression": {
       "name": "meta.embedded.block.github-actions-expression",
-      "captures": {
-        "1": {
-          "patterns": [
-            {
-              "include": "#expression"
-            }
-          ]
+      "begin": "[|-]?\\$\\{\\{",
+      "end": "\\}\\}",
+      "patterns": [
+        {
+          "include": "#expression"
         }
-      }
+      ]
     },
     "block-if-expression": {
       "contentName": "meta.embedded.block.github-actions-expression",

--- a/language/syntaxes/expressions.tmGrammar.json
+++ b/language/syntaxes/expressions.tmGrammar.json
@@ -6,6 +6,9 @@
       "include": "#expression"
     },
     {
+      "include": "#block-if-expression"
+    },
+    {
       "include": "#if-expression"
     }
   ],
@@ -38,8 +41,71 @@
         }
       }
     },
+    "block-if-expression": {
+      "contentName": "meta.embedded.block.github-actions-expression",
+      "begin": "^\\s*\\b(if:) (?:(\\|)|(>))([1-9])?([-+])?(.*\\n?)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "source.github-actions-workflow"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.flow.block-scalar.literal.yaml"
+        },
+        "3": {
+          "name": "keyword.control.flow.block-scalar.folded.yaml"
+        },
+        "4": {
+          "name": "constant.numeric.indentation-indicator.yaml"
+        },
+        "5": {
+          "name": "storage.modifier.chomping-indicator.yaml"
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "match": ".+",
+              "name": "invalid.illegal.expected-comment-or-newline.yaml"
+            }
+          ]
+        }
+      },
+      "end": "^(?=\\S)|(?!\\G)",
+      "patterns": [
+        {
+          "begin": "^([ ]+)(?! )",
+          "end": "^(?!\\1|\\s*$)",
+          "patterns": [
+            {
+              "include": "#function-call"
+            },
+            {
+              "include": "#context"
+            },
+            {
+              "include": "#string"
+            },
+            {
+              "include": "#number"
+            },
+            {
+              "include": "#boolean"
+            },
+            {
+              "include": "#null"
+            }
+          ]
+        }
+      ]
+    },
     "if-expression": {
-      "match": "\\b(if:) (.*?)$",
+      "match": "^\\s*\\b(if:) (.*?)$",
       "contentName": "meta.embedded.block.github-actions-expression",
       "captures": {
         "1": {

--- a/language/syntaxes/expressions.tmGrammar.json
+++ b/language/syntaxes/expressions.tmGrammar.json
@@ -106,6 +106,12 @@
           "include": "#string"
         },
         {
+          "include": "#op-comparison"
+        },
+        {
+          "include": "#op-logical"
+        },
+        {
           "include": "#number"
         },
         {
@@ -140,6 +146,14 @@
       "name": "string.quoted.single.github-actions-expression",
       "begin": "'",
       "end": "'"
+    },
+    "op-comparison": {
+      "name": "keyword.operator.comparison.github-actions-expression",
+      "match": "(==|!=)"
+    },
+    "op-logical": {
+      "name": "keyword.operator.logical.github-actions-expression",
+      "match": "(&&|\\|\\|)"
     },
     "number": {
       "name": "constant.numeric.github-actions-expression",


### PR DESCRIPTION
This PR bundles a few expression grammar improvements. To review it might help to look at each commit individually. If preferred, I can also split these of into separate PRs.

_The examples below are mainly taken from https://github.com/home-assistant/core/blob/dev/.github/workflows/ci.yaml_

### Fix syntax highlighting for `if` blocks
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-03 at 15 05 46](https://github.com/user-attachments/assets/f89b56d2-35b8-4fc1-8849-8cfd1ce2ac6e) | ![Screenshot 2025-05-03 at 15 06 14](https://github.com/user-attachments/assets/8881f8ca-33ad-4af0-b337-d5ba55421933) |

Before the `||` would be interpreted as the start of an unquoted block and break the syntax highlighting until the next job starts.

Fixes #224

### Disable syntax highlighting for `if` keys in comments
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-03 at 15 12 08](https://github.com/user-attachments/assets/9b79ac48-7e3b-4db7-9625-4bb91ab9e7ed) | ![Screenshot 2025-05-03 at 15 12 42](https://github.com/user-attachments/assets/b7e910ae-1fd1-4910-aaed-e3e9e9212b69) |
| ![Screenshot 2025-05-03 at 15 14 51](https://github.com/user-attachments/assets/90da9295-f93c-4be3-80e0-288323a66819) | ![Screenshot 2025-05-03 at 15 14 51](https://github.com/user-attachments/assets/90da9295-f93c-4be3-80e0-288323a66819) |

Multiline `if` blocks didn't change since they weren't even recognized in the first place previously

Fixes: #259
Fixes partially: #158 (not addressed here inline-expressions inside comments: https://github.com/github/vscode-github-actions/issues/158#issuecomment-1570255022)

### Fix syntax highlighting for inline expressions spanning multiple lines
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-03 at 15 18 48](https://github.com/user-attachments/assets/d6f66954-7762-4836-8b1a-0e4f1b02b307) | ![Screenshot 2025-05-03 at 15 19 05](https://github.com/user-attachments/assets/9ffdaebb-8de1-4ead-acb7-dfd63f5df050) |

This is quite a common pattern, especially for cache key and restore-keys.

One caveat of this change is how it affects invalid expressions. E.g. missing the closing `}}`. IMO it isn't as bad since it clearly highlights the invalid syntax. There is also the opportunity to improve on it later.

| Before | After |
| --- | --- |
| ![Screenshot 2025-05-03 at 15 20 52](https://github.com/user-attachments/assets/de490365-9b0f-4456-924f-5600b6950cbf) | ![Screenshot 2025-05-03 at 15 21 24](https://github.com/user-attachments/assets/811957da-e2d6-4658-8084-d390eba006fe) |

### Fix nested curly brackets
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-03 at 19 14 53](https://github.com/user-attachments/assets/8e8dd21d-167d-43d8-9b9e-a9b5bd76cb72) | ![Screenshot 2025-05-03 at 19 15 13](https://github.com/user-attachments/assets/85f08684-a27f-4b9c-8c33-4c84d2f87d80) |

Side effect I discovered while testing. Seems these cases are also fixed now.

Fixes #394
Fixes #223