### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/git/repository.ts
+++ b/src/git/repository.ts
@@ -78,7 +78,7 @@ export async function getGitHubUrls(): Promise<GitHubUrls[] | null> {
           remote.length > 0 &&
           (remote[0].pushUrl?.indexOf("github.com") !== -1 ||
             (useEnterprise() && remote[0].pushUrl?.indexOf(new URL(getGitHubApiUri()).host) !== -1) ||
-            remote[0].pushUrl?.indexOf(".ghe.com") !== -1)
+            (remote[0].pushUrl ? new URL(remote[0].pushUrl).host.endsWith(".ghe.com") : false))
         ) {
           const url = remote[0].pushUrl;
 


### PR DESCRIPTION
Potential fix for [https://github.com/github/vscode-github-actions/security/code-scanning/6](https://github.com/github/vscode-github-actions/security/code-scanning/6)

To fix the issue, we need to ensure that the `.ghe.com` substring check is replaced with a proper validation of the host component of the URL. This can be achieved by parsing the URL using the `URL` constructor and then checking if the host ends with `.ghe.com`. This approach ensures that the validation is performed on the correct part of the URL and cannot be bypassed by embedding `.ghe.com` in other components of the URL.

Steps to fix:
1. Parse the `pushUrl` using the `URL` constructor.
2. Extract the `host` component of the URL.
3. Check if the `host` ends with `.ghe.com` using the `endsWith` method.
4. Replace the substring check with this new validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
