### PR TITLE
feat: Show latest version of action in hover tooltip

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,9 @@ import {initResources} from "./treeViews/icons";
 import {initTreeViews} from "./treeViews/treeViews";
 import {deactivateLanguageServer, initLanguageServer} from "./workflow/languageServer";
 import {registerSignIn} from "./commands/signIn";
+import {ActionVersionHoverProvider} from "./hover/actionVersionHoverProvider";
+import {ActionVersionCodeActionProvider} from "./hover/actionVersionCodeActionProvider";
+import {WorkflowSelector, ActionSelector} from "./workflow/documentSelector";
 
 export async function activate(context: vscode.ExtensionContext) {
   initLogger();
@@ -112,6 +115,17 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Editing features
   await initLanguageServer(context);
+
+  // Action version hover and code actions
+  const documentSelectors = [WorkflowSelector, ActionSelector];
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(documentSelectors, new ActionVersionHoverProvider())
+  );
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(documentSelectors, new ActionVersionCodeActionProvider(), {
+      providedCodeActionKinds: ActionVersionCodeActionProvider.providedCodeActionKinds
+    })
+  );
 
   log("...initialized");
 

--- a/src/hover/actionVersionCodeActionProvider.ts
+++ b/src/hover/actionVersionCodeActionProvider.ts
@@ -1,0 +1,142 @@
+import * as vscode from "vscode";
+
+import {TTLCache} from "@actions/languageserver/utils/cache";
+
+import {getSession} from "../auth/auth";
+import {getClient} from "../api/api";
+
+const USES_PATTERN = /uses:\s*(['"]?)([^@\s'"]+)@([^\s'"#]+)/;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const cache = new TTLCache(CACHE_TTL_MS);
+
+interface ActionVersionInfo {
+  latest: string;
+  latestMajor?: string;
+}
+
+function parseUsesReference(
+  line: string
+): {owner: string; name: string; actionPath: string; currentRef: string; refStart: number; refEnd: number} | undefined {
+  const match = USES_PATTERN.exec(line);
+  if (!match) {
+    return undefined;
+  }
+
+  const actionPath = match[2];
+  const currentRef = match[3];
+
+  const [owner, name] = actionPath.split("/");
+  if (!owner || !name) {
+    return undefined;
+  }
+
+  // Find the position of the @ref part
+  const fullMatchStart = match.index + match[0].indexOf(match[2]);
+  const refStart = fullMatchStart + actionPath.length + 1; // +1 for @
+  const refEnd = refStart + currentRef.length;
+
+  return {owner, name, actionPath, currentRef, refStart, refEnd};
+}
+
+function extractMajorTag(tag: string): string | undefined {
+  const match = /^(v?\d+)[\.\d]*/.exec(tag);
+  return match ? match[1] : undefined;
+}
+
+async function fetchLatestVersion(owner: string, name: string): Promise<ActionVersionInfo | undefined> {
+  const session = await getSession(true);
+  if (!session) {
+    return undefined;
+  }
+
+  const cacheKey = `action-latest-version:${owner}/${name}`;
+  return cache.get<ActionVersionInfo | undefined>(cacheKey, undefined, async () => {
+    const client = getClient(session.accessToken);
+
+    try {
+      const {data} = await client.repos.getLatestRelease({owner, repo: name});
+      if (data.tag_name) {
+        const major = extractMajorTag(data.tag_name);
+        return {latest: data.tag_name, latestMajor: major};
+      }
+    } catch {
+      // No release found
+    }
+
+    try {
+      const {data} = await client.repos.listTags({owner, repo: name, per_page: 10});
+      if (data.length > 0) {
+        const semverTag = data.find(t => /^v?\d+\.\d+/.test(t.name));
+        const tag = semverTag || data[0];
+        const major = extractMajorTag(tag.name);
+        return {latest: tag.name, latestMajor: major};
+      }
+    } catch {
+      // Ignore
+    }
+
+    return undefined;
+  });
+}
+
+export class ActionVersionCodeActionProvider implements vscode.CodeActionProvider {
+  static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+
+  async provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    _context: vscode.CodeActionContext,
+    _token: vscode.CancellationToken
+  ): Promise<vscode.CodeAction[] | undefined> {
+    const actions: vscode.CodeAction[] = [];
+
+    for (let lineNum = range.start.line; lineNum <= range.end.line; lineNum++) {
+      const line = document.lineAt(lineNum).text;
+      const ref = parseUsesReference(line);
+      if (!ref) {
+        continue;
+      }
+
+      const versionInfo = await fetchLatestVersion(ref.owner, ref.name);
+      if (!versionInfo) {
+        continue;
+      }
+
+      const isCurrentLatest = ref.currentRef === versionInfo.latest || ref.currentRef === versionInfo.latestMajor;
+
+      if (isCurrentLatest) {
+        continue;
+      }
+
+      const refRange = new vscode.Range(lineNum, ref.refStart, lineNum, ref.refEnd);
+
+      // Offer update to latest full version
+      const updateToLatest = new vscode.CodeAction(
+        `Update ${ref.actionPath} to ${versionInfo.latest}`,
+        vscode.CodeActionKind.QuickFix
+      );
+      updateToLatest.edit = new vscode.WorkspaceEdit();
+      updateToLatest.edit.replace(document.uri, refRange, versionInfo.latest);
+      updateToLatest.isPreferred = true;
+      actions.push(updateToLatest);
+
+      // Offer update to latest major version tag if different
+      if (
+        versionInfo.latestMajor &&
+        versionInfo.latestMajor !== versionInfo.latest &&
+        versionInfo.latestMajor !== ref.currentRef
+      ) {
+        const updateToMajor = new vscode.CodeAction(
+          `Update ${ref.actionPath} to ${versionInfo.latestMajor}`,
+          vscode.CodeActionKind.QuickFix
+        );
+        updateToMajor.edit = new vscode.WorkspaceEdit();
+        updateToMajor.edit.replace(document.uri, refRange, versionInfo.latestMajor);
+        actions.push(updateToMajor);
+      }
+    }
+
+    return actions.length > 0 ? actions : undefined;
+  }
+}

--- a/src/hover/actionVersionCodeActionProvider.ts
+++ b/src/hover/actionVersionCodeActionProvider.ts
@@ -1,84 +1,6 @@
 import * as vscode from "vscode";
 
-import {TTLCache} from "@actions/languageserver/utils/cache";
-
-import {getSession} from "../auth/auth";
-import {getClient} from "../api/api";
-
-const USES_PATTERN = /uses:\s*(['"]?)([^@\s'"]+)@([^\s'"#]+)/;
-const CACHE_TTL_MS = 5 * 60 * 1000;
-
-const cache = new TTLCache(CACHE_TTL_MS);
-
-interface ActionVersionInfo {
-  latest: string;
-  latestMajor?: string;
-}
-
-function parseUsesReference(
-  line: string
-): {owner: string; name: string; actionPath: string; currentRef: string; refStart: number; refEnd: number} | undefined {
-  const match = USES_PATTERN.exec(line);
-  if (!match) {
-    return undefined;
-  }
-
-  const actionPath = match[2];
-  const currentRef = match[3];
-
-  const [owner, name] = actionPath.split("/");
-  if (!owner || !name) {
-    return undefined;
-  }
-
-  // Find the position of the @ref part
-  const fullMatchStart = match.index + match[0].indexOf(match[2]);
-  const refStart = fullMatchStart + actionPath.length + 1; // +1 for @
-  const refEnd = refStart + currentRef.length;
-
-  return {owner, name, actionPath, currentRef, refStart, refEnd};
-}
-
-function extractMajorTag(tag: string): string | undefined {
-  const match = /^(v?\d+)[\.\d]*/.exec(tag);
-  return match ? match[1] : undefined;
-}
-
-async function fetchLatestVersion(owner: string, name: string): Promise<ActionVersionInfo | undefined> {
-  const session = await getSession(true);
-  if (!session) {
-    return undefined;
-  }
-
-  const cacheKey = `action-latest-version:${owner}/${name}`;
-  return cache.get<ActionVersionInfo | undefined>(cacheKey, undefined, async () => {
-    const client = getClient(session.accessToken);
-
-    try {
-      const {data} = await client.repos.getLatestRelease({owner, repo: name});
-      if (data.tag_name) {
-        const major = extractMajorTag(data.tag_name);
-        return {latest: data.tag_name, latestMajor: major};
-      }
-    } catch {
-      // No release found
-    }
-
-    try {
-      const {data} = await client.repos.listTags({owner, repo: name, per_page: 10});
-      if (data.length > 0) {
-        const semverTag = data.find(t => /^v?\d+\.\d+/.test(t.name));
-        const tag = semverTag || data[0];
-        const major = extractMajorTag(tag.name);
-        return {latest: tag.name, latestMajor: major};
-      }
-    } catch {
-      // Ignore
-    }
-
-    return undefined;
-  });
-}
+import {parseUsesReference, fetchLatestVersion, isShaRef} from "./actionVersionUtils";
 
 export class ActionVersionCodeActionProvider implements vscode.CodeActionProvider {
   static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
@@ -87,15 +9,28 @@ export class ActionVersionCodeActionProvider implements vscode.CodeActionProvide
     document: vscode.TextDocument,
     range: vscode.Range | vscode.Selection,
     _context: vscode.CodeActionContext,
-    _token: vscode.CancellationToken
+    token: vscode.CancellationToken
   ): Promise<vscode.CodeAction[] | undefined> {
     const actions: vscode.CodeAction[] = [];
 
     for (let lineNum = range.start.line; lineNum <= range.end.line; lineNum++) {
+      if (token.isCancellationRequested) {
+        return actions.length > 0 ? actions : undefined;
+      }
+
       const line = document.lineAt(lineNum).text;
       const ref = parseUsesReference(line);
       if (!ref) {
         continue;
+      }
+
+      // Don't offer to replace SHA-pinned refs — it would change the security posture
+      if (isShaRef(ref.currentRef)) {
+        continue;
+      }
+
+      if (token.isCancellationRequested) {
+        return actions.length > 0 ? actions : undefined;
       }
 
       const versionInfo = await fetchLatestVersion(ref.owner, ref.name);

--- a/src/hover/actionVersionHoverProvider.ts
+++ b/src/hover/actionVersionHoverProvider.ts
@@ -1,0 +1,128 @@
+import * as vscode from "vscode";
+
+import {TTLCache} from "@actions/languageserver/utils/cache";
+
+import {getSession} from "../auth/auth";
+import {getClient} from "../api/api";
+
+const USES_PATTERN = /uses:\s*(['"]?)([^@\s'"]+)@([^\s'"#]+)/;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const cache = new TTLCache(CACHE_TTL_MS);
+
+interface ActionVersionInfo {
+  latest: string;
+  /** The latest major version tag, e.g. "v4" */
+  latestMajor?: string;
+}
+
+/**
+ * Parses the `uses:` value from a workflow line and returns owner, name, and current ref.
+ */
+function parseUsesReference(
+  line: string
+): {owner: string; name: string; currentRef: string; valueStart: number; valueEnd: number} | undefined {
+  const match = USES_PATTERN.exec(line);
+  if (!match) {
+    return undefined;
+  }
+
+  const actionPath = match[2]; // e.g. "actions/checkout" or "actions/cache/restore"
+  const currentRef = match[3];
+
+  const [owner, name] = actionPath.split("/");
+  if (!owner || !name) {
+    return undefined;
+  }
+
+  const valueStart = match.index + match[0].indexOf(match[2]);
+  const valueEnd = valueStart + actionPath.length + 1 + currentRef.length; // +1 for @
+
+  return {owner, name, currentRef, valueStart, valueEnd};
+}
+
+async function fetchLatestVersion(owner: string, name: string): Promise<ActionVersionInfo | undefined> {
+  const session = await getSession(true);
+  if (!session) {
+    return undefined;
+  }
+
+  const cacheKey = `action-latest-version:${owner}/${name}`;
+  return cache.get<ActionVersionInfo | undefined>(cacheKey, undefined, async () => {
+    const client = getClient(session.accessToken);
+
+    // Try latest release first
+    try {
+      const {data} = await client.repos.getLatestRelease({owner, repo: name});
+      if (data.tag_name) {
+        const major = extractMajorTag(data.tag_name);
+        return {latest: data.tag_name, latestMajor: major};
+      }
+    } catch {
+      // No release found, fallback to tags
+    }
+
+    // Fallback: list tags and find latest semver
+    try {
+      const {data} = await client.repos.listTags({owner, repo: name, per_page: 10});
+      if (data.length > 0) {
+        // Find the latest semver-like tag
+        const semverTag = data.find(t => /^v?\d+\.\d+/.test(t.name));
+        const tag = semverTag || data[0];
+        const major = extractMajorTag(tag.name);
+        return {latest: tag.name, latestMajor: major};
+      }
+    } catch {
+      // Ignore
+    }
+
+    return undefined;
+  });
+}
+
+function extractMajorTag(tag: string): string | undefined {
+  const match = /^(v?\d+)[\.\d]*/.exec(tag);
+  return match ? match[1] : undefined;
+}
+
+export class ActionVersionHoverProvider implements vscode.HoverProvider {
+  async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _token: vscode.CancellationToken
+  ): Promise<vscode.Hover | undefined> {
+    const line = document.lineAt(position).text;
+    const ref = parseUsesReference(line);
+    if (!ref) {
+      return undefined;
+    }
+
+    // Ensure cursor is within the action reference range
+    if (position.character < ref.valueStart || position.character > ref.valueEnd) {
+      return undefined;
+    }
+
+    const versionInfo = await fetchLatestVersion(ref.owner, ref.name);
+    if (!versionInfo) {
+      return undefined;
+    }
+
+    const md = new vscode.MarkdownString();
+    md.isTrusted = true;
+
+    const isCurrentLatest = ref.currentRef === versionInfo.latest || ref.currentRef === versionInfo.latestMajor;
+
+    if (isCurrentLatest) {
+      md.appendMarkdown(`**Latest version:** \`${versionInfo.latest}\` ✓`);
+    } else {
+      md.appendMarkdown(`**Latest version:** \`${versionInfo.latest}\``);
+      if (versionInfo.latestMajor && ref.currentRef !== versionInfo.latestMajor) {
+        md.appendMarkdown(` (major: \`${versionInfo.latestMajor}\`)`);
+      }
+    }
+
+    const range = new vscode.Range(position.line, ref.valueStart, position.line, ref.valueEnd);
+
+    return new vscode.Hover(md, range);
+  }
+}

--- a/src/hover/actionVersionHoverProvider.ts
+++ b/src/hover/actionVersionHoverProvider.ts
@@ -1,95 +1,12 @@
 import * as vscode from "vscode";
 
-import {TTLCache} from "@actions/languageserver/utils/cache";
-
-import {getSession} from "../auth/auth";
-import {getClient} from "../api/api";
-
-const USES_PATTERN = /uses:\s*(['"]?)([^@\s'"]+)@([^\s'"#]+)/;
-const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-
-const cache = new TTLCache(CACHE_TTL_MS);
-
-interface ActionVersionInfo {
-  latest: string;
-  /** The latest major version tag, e.g. "v4" */
-  latestMajor?: string;
-}
-
-/**
- * Parses the `uses:` value from a workflow line and returns owner, name, and current ref.
- */
-function parseUsesReference(
-  line: string
-): {owner: string; name: string; currentRef: string; valueStart: number; valueEnd: number} | undefined {
-  const match = USES_PATTERN.exec(line);
-  if (!match) {
-    return undefined;
-  }
-
-  const actionPath = match[2]; // e.g. "actions/checkout" or "actions/cache/restore"
-  const currentRef = match[3];
-
-  const [owner, name] = actionPath.split("/");
-  if (!owner || !name) {
-    return undefined;
-  }
-
-  const valueStart = match.index + match[0].indexOf(match[2]);
-  const valueEnd = valueStart + actionPath.length + 1 + currentRef.length; // +1 for @
-
-  return {owner, name, currentRef, valueStart, valueEnd};
-}
-
-async function fetchLatestVersion(owner: string, name: string): Promise<ActionVersionInfo | undefined> {
-  const session = await getSession(true);
-  if (!session) {
-    return undefined;
-  }
-
-  const cacheKey = `action-latest-version:${owner}/${name}`;
-  return cache.get<ActionVersionInfo | undefined>(cacheKey, undefined, async () => {
-    const client = getClient(session.accessToken);
-
-    // Try latest release first
-    try {
-      const {data} = await client.repos.getLatestRelease({owner, repo: name});
-      if (data.tag_name) {
-        const major = extractMajorTag(data.tag_name);
-        return {latest: data.tag_name, latestMajor: major};
-      }
-    } catch {
-      // No release found, fallback to tags
-    }
-
-    // Fallback: list tags and find latest semver
-    try {
-      const {data} = await client.repos.listTags({owner, repo: name, per_page: 10});
-      if (data.length > 0) {
-        // Find the latest semver-like tag
-        const semverTag = data.find(t => /^v?\d+\.\d+/.test(t.name));
-        const tag = semverTag || data[0];
-        const major = extractMajorTag(tag.name);
-        return {latest: tag.name, latestMajor: major};
-      }
-    } catch {
-      // Ignore
-    }
-
-    return undefined;
-  });
-}
-
-function extractMajorTag(tag: string): string | undefined {
-  const match = /^(v?\d+)[\.\d]*/.exec(tag);
-  return match ? match[1] : undefined;
-}
+import {parseUsesReference, fetchLatestVersion} from "./actionVersionUtils";
 
 export class ActionVersionHoverProvider implements vscode.HoverProvider {
   async provideHover(
     document: vscode.TextDocument,
     position: vscode.Position,
-    _token: vscode.CancellationToken
+    token: vscode.CancellationToken
   ): Promise<vscode.Hover | undefined> {
     const line = document.lineAt(position).text;
     const ref = parseUsesReference(line);
@@ -102,13 +19,16 @@ export class ActionVersionHoverProvider implements vscode.HoverProvider {
       return undefined;
     }
 
+    if (token.isCancellationRequested) {
+      return undefined;
+    }
+
     const versionInfo = await fetchLatestVersion(ref.owner, ref.name);
-    if (!versionInfo) {
+    if (!versionInfo || token.isCancellationRequested) {
       return undefined;
     }
 
     const md = new vscode.MarkdownString();
-    md.isTrusted = true;
 
     const isCurrentLatest = ref.currentRef === versionInfo.latest || ref.currentRef === versionInfo.latestMajor;
 

--- a/src/hover/actionVersionUtils.ts
+++ b/src/hover/actionVersionUtils.ts
@@ -1,0 +1,112 @@
+import {TTLCache} from "@actions/languageserver/utils/cache";
+
+import {getSession} from "../auth/auth";
+import {getClient} from "../api/api";
+
+const USES_PATTERN = /uses:\s*(['"]?)([^@\s'"]+)@([^\s'"#]+)/;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const cache = new TTLCache(CACHE_TTL_MS);
+
+export interface ActionVersionInfo {
+  latest: string;
+  /** The latest major version tag, e.g. "v4" */
+  latestMajor?: string;
+}
+
+export interface UsesReference {
+  owner: string;
+  name: string;
+  actionPath: string;
+  currentRef: string;
+  /** Start of the full "owner/repo@ref" value */
+  valueStart: number;
+  /** End of the full "owner/repo@ref" value */
+  valueEnd: number;
+  /** Start of just the ref part after @ */
+  refStart: number;
+  /** End of just the ref part after @ */
+  refEnd: number;
+}
+
+/**
+ * Parses the `uses:` value from a workflow line and returns owner, name, and current ref.
+ * Returns undefined for dynamic refs containing expression syntax like `${{`.
+ */
+export function parseUsesReference(line: string): UsesReference | undefined {
+  const match = USES_PATTERN.exec(line);
+  if (!match) {
+    return undefined;
+  }
+
+  const actionPath = match[2]; // e.g. "actions/checkout" or "actions/cache/restore"
+  const currentRef = match[3];
+
+  // Skip dynamic refs (e.g. ${{ github.ref }})
+  if (currentRef.includes("${{")) {
+    return undefined;
+  }
+
+  const [owner, name] = actionPath.split("/");
+  if (!owner || !name) {
+    return undefined;
+  }
+
+  const fullMatchStart = match.index + match[0].indexOf(match[2]);
+  const valueStart = fullMatchStart;
+  const refStart = fullMatchStart + actionPath.length + 1; // +1 for @
+  const refEnd = refStart + currentRef.length;
+  const valueEnd = refEnd;
+
+  return {owner, name, actionPath, currentRef, valueStart, valueEnd, refStart, refEnd};
+}
+
+export function extractMajorTag(tag: string): string | undefined {
+  const match = /^(v?\d+)[\.\d]*/.exec(tag);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Returns true if the ref looks like a commit SHA (40-char hex string).
+ */
+export function isShaRef(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+export async function fetchLatestVersion(owner: string, name: string): Promise<ActionVersionInfo | undefined> {
+  const session = await getSession();
+  if (!session) {
+    return undefined;
+  }
+
+  const cacheKey = `action-latest-version:${owner}/${name}`;
+  return cache.get<ActionVersionInfo | undefined>(cacheKey, undefined, async () => {
+    const client = getClient(session.accessToken);
+
+    // Try latest release first
+    try {
+      const {data} = await client.repos.getLatestRelease({owner, repo: name});
+      if (data.tag_name) {
+        const major = extractMajorTag(data.tag_name);
+        return {latest: data.tag_name, latestMajor: major};
+      }
+    } catch {
+      // No release found, fallback to tags
+    }
+
+    // Fallback: list tags and pick the first semver-like tag (tags are returned in creation-date order)
+    try {
+      const {data} = await client.repos.listTags({owner, repo: name, per_page: 10});
+      if (data.length > 0) {
+        const semverTag = data.find(t => /^v?\d+\.\d+/.test(t.name));
+        const tag = semverTag || data[0];
+        const major = extractMajorTag(tag.name);
+        return {latest: tag.name, latestMajor: major};
+      }
+    } catch {
+      // Ignore
+    }
+
+    return undefined;
+  });
+}


### PR DESCRIPTION

Closes #326

### Summary

When hovering over a `uses:` directive in workflow files, the extension now shows the **latest available version** of the referenced action alongside the existing language server hover (action name + description).

If the current version is outdated, a **Quick Fix** code action is available to update the version in-place.

### How it works

VS Code natively merges hover results from multiple providers. The language server continues to provide action name, description, and link — our new provider adds version information below it, separated by a divider.

### Screenshots

_Hover tooltip showing latest version:_

<img width="1154" height="603" alt="showcase-latest" src="https://github.com/user-attachments/assets/d77e607c-9a05-4dc2-982f-c8fbb56a8d61" />

<img width="1154" height="603" alt="showcase-legacy" src="https://github.com/user-attachments/assets/ba9b770b-d89e-476d-8535-2b084466f8af" />

_Quick Fix code action:_

<img width="1154" height="603" alt="showcase-quick-fix" src="https://github.com/user-attachments/assets/81ffa741-7686-4cb2-ac6e-2e70222a382f" />

### Testing

1. Open a project with `.github/workflows/` files
2. Hover over any `uses: owner/repo@ref` line → see latest version in tooltip
3. Place cursor on an outdated action → press `Cmd+.` → select update action
