### PR TITLE
chore: bump @actions/languageservices packages to 0.3.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.31.3",
       "license": "MIT",
       "dependencies": {
-        "@actions/languageserver": "^0.3.46",
-        "@actions/workflow-parser": "^0.3.46",
+        "@actions/languageserver": "^0.3.52",
+        "@actions/workflow-parser": "^0.3.52",
         "@octokit/rest": "^21.1.1",
         "@vscode/vsce": "^2.19.0",
         "buffer": "^6.0.3",
@@ -56,20 +56,22 @@
       }
     },
     "node_modules/@actions/expressions": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.51.tgz",
-      "integrity": "sha512-cnFC8OkfMUpb8qYOKKJW7j+8WnkcA8Nz3cGTnezX6K2B0UBvAWDF6rjDFDCcLcYhcK3+TNJsQsxkMDHRBHdUmw==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.52.tgz",
+      "integrity": "sha512-WIFQzwL20jFHCGR7Fy8vCTbW9nD9+xfLdxR8S38CU02PtdujG4ecbORhq7howd0ZcSVb5rFiUPorXv0kosDzlQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@actions/languageserver": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.51.tgz",
-      "integrity": "sha512-jgYTwFZbcudhYlNiIHnMz02vjkeiIjW856BM4qC47Ryg2k1c5po3saZz1N2gH3/T56eZIWIaRujS2rNwIg6yDA==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.52.tgz",
+      "integrity": "sha512-X1x+JeZe/aDNTNm8yxbC2yLwrzYkVmNeU3/UNDDezeQhyqUIBD6w5U3fUHrN+F2VNklR6XT8hj220dK/1VmDuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/languageservice": "^0.3.51",
-        "@actions/workflow-parser": "^0.3.51",
+        "@actions/languageservice": "^0.3.52",
+        "@actions/workflow-parser": "^0.3.52",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -99,12 +101,13 @@
       }
     },
     "node_modules/@actions/languageservice": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.51.tgz",
-      "integrity": "sha512-uOvYNZtr/pNKBxBhFDyPKK6wXULlZcnkB3T30nQJV3ea7c66bAkCfHqHeT8nnngXDw2icdMjjGfraZyRvj7aew==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.52.tgz",
+      "integrity": "sha512-lOhwV9F2l9d5n4qwZ6WZ6Cp+LfIG1t8boIfvxaktbR1EL/Cv/DwaSu7QJPH22nf2oUT2M5V/A4R5dtBKfT1vOw==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.51",
-        "@actions/workflow-parser": "^0.3.51",
+        "@actions/expressions": "^0.3.52",
+        "@actions/workflow-parser": "^0.3.52",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -115,11 +118,12 @@
       }
     },
     "node_modules/@actions/workflow-parser": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.51.tgz",
-      "integrity": "sha512-nGVLucxBpeF53rHMJ7zdilu0Y+pjDb1/SmMq5O93sOViBo+me9IAfNKU6yDvtY3dzdbZzhqiVTU6PeIeaQj9hw==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.52.tgz",
+      "integrity": "sha512-2HTDNkOtsGZKCRgVvoaz8mDI4qQ4QuMIoFmONbwkYMoUak+mGqGoYNuLxCutNfa6t/CGgmtmqwrT77u+w9/0Bg==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.51",
+        "@actions/expressions": "^0.3.52",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       },
@@ -3580,6 +3584,7 @@
       "version": "2.59.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
       "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
+      "license": "MIT",
       "bin": {
         "cronstrue": "bin/cli.js"
       }
@@ -10160,7 +10165,8 @@
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
@@ -10473,6 +10479,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -10542,17 +10549,17 @@
   },
   "dependencies": {
     "@actions/expressions": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.51.tgz",
-      "integrity": "sha512-cnFC8OkfMUpb8qYOKKJW7j+8WnkcA8Nz3cGTnezX6K2B0UBvAWDF6rjDFDCcLcYhcK3+TNJsQsxkMDHRBHdUmw=="
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.52.tgz",
+      "integrity": "sha512-WIFQzwL20jFHCGR7Fy8vCTbW9nD9+xfLdxR8S38CU02PtdujG4ecbORhq7howd0ZcSVb5rFiUPorXv0kosDzlQ=="
     },
     "@actions/languageserver": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.51.tgz",
-      "integrity": "sha512-jgYTwFZbcudhYlNiIHnMz02vjkeiIjW856BM4qC47Ryg2k1c5po3saZz1N2gH3/T56eZIWIaRujS2rNwIg6yDA==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.52.tgz",
+      "integrity": "sha512-X1x+JeZe/aDNTNm8yxbC2yLwrzYkVmNeU3/UNDDezeQhyqUIBD6w5U3fUHrN+F2VNklR6XT8hj220dK/1VmDuQ==",
       "requires": {
-        "@actions/languageservice": "^0.3.51",
-        "@actions/workflow-parser": "^0.3.51",
+        "@actions/languageservice": "^0.3.52",
+        "@actions/workflow-parser": "^0.3.52",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -10576,12 +10583,12 @@
       }
     },
     "@actions/languageservice": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.51.tgz",
-      "integrity": "sha512-uOvYNZtr/pNKBxBhFDyPKK6wXULlZcnkB3T30nQJV3ea7c66bAkCfHqHeT8nnngXDw2icdMjjGfraZyRvj7aew==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.52.tgz",
+      "integrity": "sha512-lOhwV9F2l9d5n4qwZ6WZ6Cp+LfIG1t8boIfvxaktbR1EL/Cv/DwaSu7QJPH22nf2oUT2M5V/A4R5dtBKfT1vOw==",
       "requires": {
-        "@actions/expressions": "^0.3.51",
-        "@actions/workflow-parser": "^0.3.51",
+        "@actions/expressions": "^0.3.52",
+        "@actions/workflow-parser": "^0.3.52",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -10589,11 +10596,11 @@
       }
     },
     "@actions/workflow-parser": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.51.tgz",
-      "integrity": "sha512-nGVLucxBpeF53rHMJ7zdilu0Y+pjDb1/SmMq5O93sOViBo+me9IAfNKU6yDvtY3dzdbZzhqiVTU6PeIeaQj9hw==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.52.tgz",
+      "integrity": "sha512-2HTDNkOtsGZKCRgVvoaz8mDI4qQ4QuMIoFmONbwkYMoUak+mGqGoYNuLxCutNfa6t/CGgmtmqwrT77u+w9/0Bg==",
       "requires": {
-        "@actions/expressions": "^0.3.51",
+        "@actions/expressions": "^0.3.52",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       }

--- a/package.json
+++ b/package.json
@@ -563,8 +563,8 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@actions/languageserver": "^0.3.46",
-    "@actions/workflow-parser": "^0.3.46",
+    "@actions/languageserver": "^0.3.52",
+    "@actions/workflow-parser": "^0.3.52",
     "@octokit/rest": "^21.1.1",
     "@vscode/vsce": "^2.19.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
## Summary

Bumps `@actions/languageserver` and `@actions/workflow-parser` from ^0.3.46 → ^0.3.52.

### What's new

- **`job.workflow_*` context properties** — autocomplete, validation, and hover for `job.workflow_ref`, `job.workflow_sha`, `job.workflow_repository`, `job.workflow_file_path`

### Related

- Language services PR: https://github.com/actions/languageservices/pull/348
- Release: https://github.com/actions/languageservices/releases/tag/release-v0.3.52