### PR TITLE
Enable allowBackgroundSteps language server feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/languageserver": "^0.3.46",
-        "@actions/workflow-parser": "^0.3.46",
+        "@actions/languageserver": "^0.3.58",
+        "@actions/workflow-parser": "^0.3.58",
         "@octokit/rest": "^21.1.1",
         "@vscode/vsce": "^2.19.0",
         "buffer": "^6.0.3",
@@ -58,20 +58,22 @@
       }
     },
     "node_modules/@actions/expressions": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.54.tgz",
-      "integrity": "sha512-7sUDgjK84EuifJSa/7H9Gu3SWIESl66/LmPvMIkSbWgLEp/KjKQpsoDCYtzzi1K8aW8eUjwVxxit++gbOTC6Aw==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.58.tgz",
+      "integrity": "sha512-akOPmhjI/a4TRArNR0nQqfsE+5/xNvhZWOKbT8QkHCEsoLC19L/uCZfxhjyvWLLh17tGG4jjdo5RHCvkfQBdNA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@actions/languageserver": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.54.tgz",
-      "integrity": "sha512-STUofO6j0huHgEppTVoyFhqQrZLNv2Od6Bo5VUJSqVyIEhTeoyH6jLjPhBrf5dFXd7BnLsvjR5U1zzW8alzsIA==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.58.tgz",
+      "integrity": "sha512-zNOkOUifRnvbVEWbxaKIGlrpAQBWsvoDOEaOu5EBSWB6IYSXIghtZCbKDSyB7+s+zNDnsobax8w10r0oc1XSqQ==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/languageservice": "^0.3.54",
-        "@actions/workflow-parser": "^0.3.54",
+        "@actions/languageservice": "^0.3.58",
+        "@actions/workflow-parser": "^0.3.58",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -101,12 +103,13 @@
       }
     },
     "node_modules/@actions/languageservice": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.54.tgz",
-      "integrity": "sha512-/6Ez83TRGhS9Cq8LWgg7/2F+WWreiEDm0I9W6ir6zglgTIdF7JYveY1Lj8CvWCFPG9TKYdcP7yIYgjQpZS7V6A==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.58.tgz",
+      "integrity": "sha512-C705QSWaODQWH7vJCVGGPqoAuykaUrbVx5yqhJVdtcR5X8IohXBM8v+0vWv9URUOXfzj7OQUHLYTTbCO6Bkz9w==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.54",
-        "@actions/workflow-parser": "^0.3.54",
+        "@actions/expressions": "^0.3.58",
+        "@actions/workflow-parser": "^0.3.58",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -117,11 +120,12 @@
       }
     },
     "node_modules/@actions/workflow-parser": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.54.tgz",
-      "integrity": "sha512-o4nDknc8sj8wKwFdpVT2uew2NYEIaJs4E7gV0v4MSjppW/IKB1QabrziFpdmeBuqTNnbul+8UpXdJrQGD9ViKA==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.58.tgz",
+      "integrity": "sha512-79TeA1xsu15E0Enzbt6QZCxTztF3sSdj0/QsA8aC6OHt3dVdnXWRymgkHRQu5sOGyEPCsBAg6uO5jdVP6wVKdA==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.54",
+        "@actions/expressions": "^0.3.58",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       },
@@ -3592,6 +3596,7 @@
       "version": "2.59.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
       "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
+      "license": "MIT",
       "bin": {
         "cronstrue": "bin/cli.js"
       }
@@ -10172,7 +10177,8 @@
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
@@ -10503,9 +10509,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -10575,17 +10582,17 @@
   },
   "dependencies": {
     "@actions/expressions": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.54.tgz",
-      "integrity": "sha512-7sUDgjK84EuifJSa/7H9Gu3SWIESl66/LmPvMIkSbWgLEp/KjKQpsoDCYtzzi1K8aW8eUjwVxxit++gbOTC6Aw=="
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.58.tgz",
+      "integrity": "sha512-akOPmhjI/a4TRArNR0nQqfsE+5/xNvhZWOKbT8QkHCEsoLC19L/uCZfxhjyvWLLh17tGG4jjdo5RHCvkfQBdNA=="
     },
     "@actions/languageserver": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.54.tgz",
-      "integrity": "sha512-STUofO6j0huHgEppTVoyFhqQrZLNv2Od6Bo5VUJSqVyIEhTeoyH6jLjPhBrf5dFXd7BnLsvjR5U1zzW8alzsIA==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.58.tgz",
+      "integrity": "sha512-zNOkOUifRnvbVEWbxaKIGlrpAQBWsvoDOEaOu5EBSWB6IYSXIghtZCbKDSyB7+s+zNDnsobax8w10r0oc1XSqQ==",
       "requires": {
-        "@actions/languageservice": "^0.3.54",
-        "@actions/workflow-parser": "^0.3.54",
+        "@actions/languageservice": "^0.3.58",
+        "@actions/workflow-parser": "^0.3.58",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -10609,12 +10616,12 @@
       }
     },
     "@actions/languageservice": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.54.tgz",
-      "integrity": "sha512-/6Ez83TRGhS9Cq8LWgg7/2F+WWreiEDm0I9W6ir6zglgTIdF7JYveY1Lj8CvWCFPG9TKYdcP7yIYgjQpZS7V6A==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.58.tgz",
+      "integrity": "sha512-C705QSWaODQWH7vJCVGGPqoAuykaUrbVx5yqhJVdtcR5X8IohXBM8v+0vWv9URUOXfzj7OQUHLYTTbCO6Bkz9w==",
       "requires": {
-        "@actions/expressions": "^0.3.54",
-        "@actions/workflow-parser": "^0.3.54",
+        "@actions/expressions": "^0.3.58",
+        "@actions/workflow-parser": "^0.3.58",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -10622,11 +10629,11 @@
       }
     },
     "@actions/workflow-parser": {
-      "version": "0.3.54",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.54.tgz",
-      "integrity": "sha512-o4nDknc8sj8wKwFdpVT2uew2NYEIaJs4E7gV0v4MSjppW/IKB1QabrziFpdmeBuqTNnbul+8UpXdJrQGD9ViKA==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.58.tgz",
+      "integrity": "sha512-79TeA1xsu15E0Enzbt6QZCxTztF3sSdj0/QsA8aC6OHt3dVdnXWRymgkHRQu5sOGyEPCsBAg6uO5jdVP6wVKdA==",
       "requires": {
-        "@actions/expressions": "^0.3.54",
+        "@actions/expressions": "^0.3.58",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       }
@@ -18298,9 +18305,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="
     },
     "yargs": {
       "version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -582,8 +582,8 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@actions/languageserver": "^0.3.46",
-    "@actions/workflow-parser": "^0.3.46",
+    "@actions/languageserver": "^0.3.58",
+    "@actions/workflow-parser": "^0.3.58",
     "@octokit/rest": "^21.1.1",
     "@vscode/vsce": "^2.19.0",
     "buffer": "^6.0.3",

--- a/src/workflow/languageServer.ts
+++ b/src/workflow/languageServer.ts
@@ -37,7 +37,8 @@ export async function initLanguageServer(context: vscode.ExtensionContext) {
     })),
     logLevel: PRODUCTION ? LogLevel.Warn : LogLevel.Debug,
     experimentalFeatures: {
-      allowCaseFunction: true
+      allowCaseFunction: true,
+      allowBackgroundSteps: true
     }
   };
 


### PR DESCRIPTION
Background steps (`background`, `wait`, `wait-all`, `cancel`, `parallel`) are enabled server-side everywhere. 

This enables `allowBackgroundSteps` in the language client's initialization options (alongside `allowCaseFunction`), so validation and completion accept the new keywords. 

Related to https://github.com/github/vscode-github-actions/issues/605