### PR TITLE
Support composite actions files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
         ],
         "filenamePatterns": [
           "**/.github/workflows/**/*.yml",
-          "**/.github/workflows/**/*.yaml"
+          "**/.github/workflows/**/*.yaml",
+          "**/action.yml",
+          "**/action.yaml"
         ],
         "configuration": "./language/language-configuration.json",
         "icon": {


### PR DESCRIPTION
Closes #497 

#497 was mentioned in https://github.com/actions/languageservices/pull/275 and that was merged earlier this year, so I'm hoping the only thing preventing support in composite actions was the lack of `action.yml` in the filename patterns. 🤞 