### PR TITLE
Bump actions language server to 0.3.60 for $/ self repository support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.32.2",
       "license": "MIT",
       "dependencies": {
-        "@actions/languageserver": "^0.3.58",
-        "@actions/workflow-parser": "^0.3.58",
+        "@actions/languageserver": "^0.3.60",
+        "@actions/workflow-parser": "^0.3.60",
         "@octokit/rest": "^21.1.1",
         "@vscode/vsce": "^2.19.0",
         "buffer": "^6.0.3",
@@ -58,20 +58,22 @@
       }
     },
     "node_modules/@actions/expressions": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.59.tgz",
-      "integrity": "sha512-YoMBCK8OjcH0giqmv6lKteZDYe43tWhhyz68D914LbDs+Svjbf0LFyOpMRkYWJ49BokU7QrlLBt1n91DggXywA==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.60.tgz",
+      "integrity": "sha512-9Go4zz77GbM6iUkullgo0tN7AHgUNRLkw66C6k3mHEc/QScweRNffjSluS0jcip+ULGkDYzBnyMvY9RjnFjEMA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@actions/languageserver": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.59.tgz",
-      "integrity": "sha512-Rzo998hw32pg1mfnDHJqa74d9F4jIaaLLMA5jl6mH8JiUHTXJwESMNWTVH9HK0El9HOeV6DgRCUP7cLGDg6XQw==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.60.tgz",
+      "integrity": "sha512-HEr+xBoymJ92FNr6KY6a/uhy03Rmn/yz5gBeMn9qJpo6HO7cohBH4RGXGkzIvUBJOnbz9BB/OFdlQsWu4zqKDA==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/languageservice": "^0.3.59",
-        "@actions/workflow-parser": "^0.3.59",
+        "@actions/languageservice": "^0.3.60",
+        "@actions/workflow-parser": "^0.3.60",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -101,12 +103,13 @@
       }
     },
     "node_modules/@actions/languageservice": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.59.tgz",
-      "integrity": "sha512-xvOuzHQ5BRJwoat5wMhUREwLQuqk0diUymrzqyExZq8M+zWlnlFqMmwnJgDnwciaSkqSeiJmDpey5UGAaWkWdw==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.60.tgz",
+      "integrity": "sha512-eOIvq4b8yDh/O+hEPFsuXTb5qMquWQJtRyI7vidSHDPKrcZjvXDxcY/1y0JKzZRnrbar50Lc3yzxBLL2hbwobQ==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.59",
-        "@actions/workflow-parser": "^0.3.59",
+        "@actions/expressions": "^0.3.60",
+        "@actions/workflow-parser": "^0.3.60",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -117,11 +120,12 @@
       }
     },
     "node_modules/@actions/workflow-parser": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.59.tgz",
-      "integrity": "sha512-at3p1Hq6wdjlr7NTrVTyxhBqU4jjFLyVJYfZhUcXO7E3gbduS9YirVkUMLHpT6perGnOsrxievf5FrXs7z+REQ==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.60.tgz",
+      "integrity": "sha512-23dHOAA0BE4yA+0Lq9VuOdfjMnucVVYw/1fnbnEy3l814q7h4ET8+QE+zusOoLulln3/6UmeJUkmo1etOnlVBw==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/expressions": "^0.3.59",
+        "@actions/expressions": "^0.3.60",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       },
@@ -3592,6 +3596,7 @@
       "version": "2.59.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
       "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
+      "license": "MIT",
       "bin": {
         "cronstrue": "bin/cli.js"
       }
@@ -10172,7 +10177,8 @@
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
@@ -10506,6 +10512,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -10575,17 +10582,17 @@
   },
   "dependencies": {
     "@actions/expressions": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.59.tgz",
-      "integrity": "sha512-YoMBCK8OjcH0giqmv6lKteZDYe43tWhhyz68D914LbDs+Svjbf0LFyOpMRkYWJ49BokU7QrlLBt1n91DggXywA=="
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/expressions/-/expressions-0.3.60.tgz",
+      "integrity": "sha512-9Go4zz77GbM6iUkullgo0tN7AHgUNRLkw66C6k3mHEc/QScweRNffjSluS0jcip+ULGkDYzBnyMvY9RjnFjEMA=="
     },
     "@actions/languageserver": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.59.tgz",
-      "integrity": "sha512-Rzo998hw32pg1mfnDHJqa74d9F4jIaaLLMA5jl6mH8JiUHTXJwESMNWTVH9HK0El9HOeV6DgRCUP7cLGDg6XQw==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/languageserver/-/languageserver-0.3.60.tgz",
+      "integrity": "sha512-HEr+xBoymJ92FNr6KY6a/uhy03Rmn/yz5gBeMn9qJpo6HO7cohBH4RGXGkzIvUBJOnbz9BB/OFdlQsWu4zqKDA==",
       "requires": {
-        "@actions/languageservice": "^0.3.59",
-        "@actions/workflow-parser": "^0.3.59",
+        "@actions/languageservice": "^0.3.60",
+        "@actions/workflow-parser": "^0.3.60",
         "@octokit/rest": "^21.1.1",
         "@octokit/types": "^9.0.0",
         "vscode-languageserver": "^8.0.2",
@@ -10609,12 +10616,12 @@
       }
     },
     "@actions/languageservice": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.59.tgz",
-      "integrity": "sha512-xvOuzHQ5BRJwoat5wMhUREwLQuqk0diUymrzqyExZq8M+zWlnlFqMmwnJgDnwciaSkqSeiJmDpey5UGAaWkWdw==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/languageservice/-/languageservice-0.3.60.tgz",
+      "integrity": "sha512-eOIvq4b8yDh/O+hEPFsuXTb5qMquWQJtRyI7vidSHDPKrcZjvXDxcY/1y0JKzZRnrbar50Lc3yzxBLL2hbwobQ==",
       "requires": {
-        "@actions/expressions": "^0.3.59",
-        "@actions/workflow-parser": "^0.3.59",
+        "@actions/expressions": "^0.3.60",
+        "@actions/workflow-parser": "^0.3.60",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
         "vscode-uri": "^3.0.8",
@@ -10622,11 +10629,11 @@
       }
     },
     "@actions/workflow-parser": {
-      "version": "0.3.59",
-      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.59.tgz",
-      "integrity": "sha512-at3p1Hq6wdjlr7NTrVTyxhBqU4jjFLyVJYfZhUcXO7E3gbduS9YirVkUMLHpT6perGnOsrxievf5FrXs7z+REQ==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@actions/workflow-parser/-/workflow-parser-0.3.60.tgz",
+      "integrity": "sha512-23dHOAA0BE4yA+0Lq9VuOdfjMnucVVYw/1fnbnEy3l814q7h4ET8+QE+zusOoLulln3/6UmeJUkmo1etOnlVBw==",
       "requires": {
-        "@actions/expressions": "^0.3.59",
+        "@actions/expressions": "^0.3.60",
         "cronstrue": "^2.21.0",
         "yaml": "^2.0.0-8"
       }

--- a/package.json
+++ b/package.json
@@ -582,8 +582,8 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@actions/languageserver": "^0.3.58",
-    "@actions/workflow-parser": "^0.3.58",
+    "@actions/languageserver": "^0.3.60",
+    "@actions/workflow-parser": "^0.3.60",
     "@octokit/rest": "^21.1.1",
     "@vscode/vsce": "^2.19.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Also picks up the changes in v0.3.59 of the languageservice/workflow parser, but these should be okay to include in this PR:
- graduating concurrency-queue feature flag which has no cleanup here.
- drives permission, which just needs the bump.